### PR TITLE
创建task相关结构体

### DIFF
--- a/os/src/arch/riscv/kernel/context.rs
+++ b/os/src/arch/riscv/kernel/context.rs
@@ -1,0 +1,10 @@
+/// 在发生调度时保存的上下文信息
+/// 相较于TrapFram只保存切换所需的最少量寄存器
+pub struct Context {
+    /// 返回地址
+    pub ra: usize,
+    /// 栈指针
+    pub sp: usize,
+    /// 保存s0-s11寄存器
+    pub s: [usize; 12],
+}

--- a/os/src/arch/riscv/kernel/mod.rs
+++ b/os/src/arch/riscv/kernel/mod.rs
@@ -1,0 +1,1 @@
+pub mod context;

--- a/os/src/arch/riscv/mod.rs
+++ b/os/src/arch/riscv/mod.rs
@@ -1,3 +1,4 @@
+pub mod kernel;
 pub mod constant;
 pub mod intr;
 pub mod mm;

--- a/os/src/arch/riscv/trap/kerneltrap.rs
+++ b/os/src/arch/riscv/trap/kerneltrap.rs
@@ -9,7 +9,7 @@ use crate::arch::timer::TIMER_TICKS;
 
 // XXX: CSR可能因调度或中断被修改？
 #[unsafe(no_mangle)]
-pub extern "C" fn kerneltrap(_trap_frame: &mut KernelTrapFrame) {
+pub extern "C" fn kerneltrap(_trap_frame: &mut TrapFrame) {
     // 陷阱帧的地址（sp）被隐式地作为参数 a0 传递给了 kerneltrap
     // 在这里，trap_frame 指向了栈上保存的 KernelTrapFrame 结构体
 
@@ -56,7 +56,7 @@ pub extern "C" fn kerneltrap(_trap_frame: &mut KernelTrapFrame) {
 
 #[repr(C)] // 确保 Rust 不会重新排列字段
 #[derive(Debug, Clone, Copy)]
-pub struct KernelTrapFrame {
+pub struct TrapFrame {
     pub x1_ra: usize,  // 0(sp)
     pub x2_sp: usize,  // 8(sp)
     pub x3_gp: usize,  // 16(sp)

--- a/os/src/arch/riscv/trap/mod.rs
+++ b/os/src/arch/riscv/trap/mod.rs
@@ -1,4 +1,4 @@
-mod kerneltrap;
+pub mod kerneltrap;
 
 use core::arch::global_asm;
 use riscv::register::{

--- a/os/src/kernel/mod.rs
+++ b/os/src/kernel/mod.rs
@@ -1,0 +1,2 @@
+pub mod task_info;
+pub mod task_struct;

--- a/os/src/kernel/task_info.rs
+++ b/os/src/kernel/task_info.rs
@@ -1,0 +1,28 @@
+/// 关于任务的管理信息
+/// 存放与调度器、任务状态、队列相关的、需要高频访问和修改的数据。
+/// 主要由调度器子系统使用。
+pub struct TaskInfo {
+    /// 任务的抢占计数器，表示当前任务被禁止抢占的次数
+    /// 当该值大于0时，表示任务处于不可抢占状态
+    preempt_count: usize,
+    /// 任务的优先级，数值越小优先级越高
+    priority: u8,
+    /// 任务所在的处理器id
+    processor_id: usize,
+    /// 任务当前的状态
+    state: TaskState,
+    /// 任务的id
+    tid: usize,
+}
+
+/// 任务状态
+pub enum TaskState {
+    /// 可执行。正在执行或可被调度执行
+    RUNNING,
+    /// 停止。没有也不能执行
+    STOPPED,
+    /// 等待可中断的事件。可以被信号等中断唤醒
+    INTERRUPTABLE,
+    /// 等待不可中断的事件。不能被信号等中断唤醒
+    UNINTERRUPTABLE,
+}

--- a/os/src/kernel/task_struct.rs
+++ b/os/src/kernel/task_struct.rs
@@ -1,0 +1,19 @@
+use crate::arch::kernel::context::Context;
+use crate::arch::trap::kerneltrap::TrapFrame;
+
+/// 关于任务的资源信息
+/// 存放与进程资源、内存管理、I/O 权限、用户 ID 等相关的、相对稳定或低频访问的数据。
+/// 主要由内存管理子系统和权限管理子系统使用。
+pub struct TaskStruct {
+    /// 内核栈基址
+    kstack_base: usize,
+    /// 中断上下文。指向当前任务内核栈上的 TrapFrame，仅在任务被中断时有效。
+    trap_frame_ptr: *mut TrapFrame,
+    /// 任务上下文，用于任务切换
+    context: Context,
+    /// 父任务的id
+    parient_tid: usize,
+    /// 退出码
+    exit_code: isize,
+    // TODO: 由于部分相关子系统尚未实现，暂时留空
+}

--- a/os/src/main.rs
+++ b/os/src/main.rs
@@ -13,6 +13,7 @@ mod config;
 mod mm;
 mod arch;
 mod sync;
+mod kernel;
 
 mod test;
 use crate::test::TEST_FAILED;


### PR DESCRIPTION
**Related to #8: 创建task相关结构体**

本次PR实现了 Issue #8 的**第一阶段需求**：

**完成的部分：**
- [x] 任务和上下文。
- [ ] 调度器 。
- [ ] 用户模式。

**主要贡献：**
定义核心数据结构 `TaskInfo` 和 `TaskStruct`。

**下一步：**
由于创建内核态任务需要分配内核栈，似乎要等到分页机制编写完毕才能进一步编写。