### PR TITLE
fix: 解决了不能进入rust_main的问题

### DIFF
--- a/os/src/entry.asm
+++ b/os/src/entry.asm
@@ -10,27 +10,50 @@ _start:
     sfence.vma               # 刷新 TLB
 
     # 2. 跳转到高地址
-    la t0, _start_high
+    # 参考其他OS的做法: la加载物理地址,然后or上虚拟地址偏移
+    # VADDR_START = 0xffff_ffc0_0000_0000 (arch/riscv/mm/mod.rs)
+    # 或者 VIRTUAL_BASE = 0xffffffffc0200000 (linker.ld, 符号扩展形式)
+    # 实际上两者的高位部分相同,都是将bit38-63设置为1
+    la t0, _start_high       # t0 = _start_high的物理地址
+    li t1, -1                # t1 = 0xffffffff_ffffffff
+    slli t1, t1, 38          # t1 = 0xffffffc0_00000000 (清除低38位,设置高位)
+    or t0, t0, t1            # 将物理地址转换为虚拟地址
     jr t0
 
 _start_high:
     # 3. 现在 PC 在高地址，可以安全使用虚拟地址
+    # 加载栈指针,需要确保是虚拟地址
     la sp, boot_stack_top
+    li t0, -1
+    slli t0, t0, 38          # t0 = 0xffffffc0_00000000
+    or sp, sp, t0            # 将栈地址转换为虚拟地址
     call rust_main
 
     .section .data
     .align 12
 boot_pagetable:
     # 早期页表：只映射内核段（恒等 + 高地址）
-    # PTE[2]: 0x00000000_80000000 -> 0x80000000 (恒等映射，用于启动)
+    # PTE[0-1]: 未使用
+    .8byte 0
+    .8byte 0
+    # PTE[2]: 0x80000000 -> 0x80000000 (恒等映射，用于启动)
     .8byte (0x80000 << 10) | 0xef  # PPN=0x80000, V|R|W|X|A|D|G
 
-    # PTE[?]: 0xffffffffc0000000 -> 0x80000000 (高地址映射，内核使用)
-    # 计算 VPN[2] = 0xffffffffc0000000 >> 30 & 0x1ff = 0x100
-    .zero 8 * (0x100 - 1)          # 填充到索引 0x100
-    .8byte (0x80000 << 10) | 0xef  # 同样映射到物理地址 0x80000000
+    # PTE[3-255]: 填充
+    .zero 8 * (0x100 - 3)          # 填充从索引3到索引255
 
-    .zero 8 * (512 - 0x100 - 2)    # 填充剩余项
+    # PTE[256-259]: 高地址映射，映射4个1GB页面以覆盖整个内核空间
+    # PTE[256]: 0xffff_ffc0_0000_0000 -> 0x00000000
+    .8byte (0x00000 << 10) | 0xcf
+    # PTE[257]: 0xffff_ffc0_4000_0000 -> 0x40000000
+    .8byte (0x40000 << 10) | 0xcf
+    # PTE[258]: 0xffff_ffc0_8000_0000 -> 0x80000000 (内核所在)
+    .8byte (0x80000 << 10) | 0xcf
+    # PTE[259]: 0xffff_ffc0_c000_0000 -> 0xc0000000
+    .8byte (0xc0000 << 10) | 0xcf
+
+    # PTE[260-511]: 填充剩余项
+    .zero 8 * (512 - 0x100 - 4)    # 填充从索引260到511
 
     .section .bss.stack
     .globl boot_stack_lower_bound

--- a/os/src/linker.ld
+++ b/os/src/linker.ld
@@ -1,7 +1,7 @@
 OUTPUT_ARCH(riscv)
 ENTRY(_start)
 PHYSICAL_BASE = 0x80200000;           /* 物理地址 */
-VIRTUAL_BASE = 0xffffffffc0200000;    /* 虚拟地址（高半核） */
+VIRTUAL_BASE = 0xffffffc080200000;    /* 虚拟地址（高半核），与arch/mm保持一致 */
 
 SECTIONS
 {


### PR DESCRIPTION
## 问题描述

内核在启动时无法成功进入 `rust_main` 函数，导致无法打印 "Hello, world!"。

通过 GDB 调试发现根本原因：
- 早期页表映射范围不足，只映射了 PTE[256]，但内核代码实际需要 PTE[258]
- linker.ld 的 VIRTUAL_BASE 与 arch/riscv/mm 的 VADDR_START 不一致
- 跳转到高地址时缺少正确的虚拟地址转换

## 修复内容

### 1. entry.asm
- **扩展页表映射**：从单个 PTE[256] 扩展为 PTE[256-259]，映射 4 个连续的 1GB 页面
- **修复地址转换**：跳转到高地址和设置栈指针时，使用 `li t1, -1; slli t1, t1, 38; or` 进行虚拟地址转换
- **添加显式零条目**：PTE[0-1] 显式设为 0，确保索引对齐

### 2. linker.ld
- **统一虚拟地址**：VIRTUAL_BASE 从 `0xffffffffc0200000` 改为 `0xffffffc080200000`，与 arch/riscv/mm 保持一致

## 技术说明

在 SV39 中，虚拟地址 `0xffffffc080200000` 的 VPN[2] = 258，因此必须映射 PTE[258] 才能访问内核代码。

## 测试验证

通过 GDB 验证内核成功启动并进入 rust_main