### PR TITLE
test: 为taskstruct编写单元测试

### DIFF
--- a/os/src/kernel/task/task_struct.rs
+++ b/os/src/kernel/task/task_struct.rs
@@ -151,3 +151,37 @@ impl Task {
 // /// 主要由内存管理子系统和权限管理子系统使用。
 // #[allow(dead_code)]
 // pub struct TaskStruct {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{kassert, test_case};
+
+    // 创建内核任务的基本属性检查
+    test_case!(test_ktask_create_basic, {
+        println!("Testing: test_ktask_create_basic");
+        let t = Task::ktask_create(0);
+        // tid/ pid 应有效且相等
+        kassert!(t.tid != 0);
+        kassert!(t.pid == t.tid);
+        // 默认创建为内核线程（memory_space == None）
+        kassert!(t.is_kernel_thread());
+        // 内核栈基址应非零
+        kassert!(t.kstack_base != 0);
+        // 初始 trap_frame_ptr 应为 null
+        kassert!(t.trap_frame_ptr.load(Ordering::SeqCst).is_null());
+    });
+
+    // 初始化内核线程上下文（sp/ra）检查
+    test_case!(test_init_kernel_thread_context, {
+        println!("Testing: test_init_kernel_thread_context");
+        let mut t = Task::ktask_create(0);
+        let entry = 0x1000usize;
+        t.init_kernel_thread_context(entry);
+        // sp 应为栈顶（kstack_base），ra 应为入口地址
+        kassert!(t.context.sp == t.kstack_base);
+        kassert!(t.context.ra == entry);
+        // 内核线程不应在创建时拥有有效的 trap_frame_ptr
+        kassert!(t.trap_frame_ptr.load(Ordering::SeqCst).is_null());
+    });
+}


### PR DESCRIPTION
This pull request adds unit tests for the `Task` struct in `task_struct.rs`, focusing on the creation and initialization of kernel tasks. The tests ensure that kernel task creation and context initialization behave as expected.

Testing improvements:

* Added a test (`test_ktask_create_basic`) to verify the basic properties of a newly created kernel task, including valid `tid` and `pid`, correct kernel thread status, non-zero kernel stack base, and a null initial `trap_frame_ptr`.
* Added a test (`test_init_kernel_thread_context`) to verify that initializing a kernel thread context sets the stack pointer (`sp`) and return address (`ra`) correctly, and that the `trap_frame_ptr` remains null.