### PR TITLE
test: 修正测试

### DIFF
--- a/os/src/arch/riscv/timer.rs
+++ b/os/src/arch/riscv/timer.rs
@@ -54,8 +54,11 @@ mod tests {
     test_case!(test_timer_ticks_increment, {
         let initial_ticks = TIMER_TICKS.load(Ordering::Relaxed);
         // 模拟等待一段时间以触发定时器中断
-        for _ in 0..1000000 {
+        let mut i = 0;
+
+        while i < 1000000 {
             core::hint::spin_loop();
+            i += 1;
         }
         let later_ticks = TIMER_TICKS.load(Ordering::Relaxed);
         kassert!(later_ticks > initial_ticks);


### PR DESCRIPTION
此拉取请求主要恢复并改进`task_struct.rs`中的内核任务单元测试，并对`timer.rs`中的计时器测试进行了微调。最显著的更新是重新启用并增强了内核任务创建和上下文初始化测试，这有助于确保任务管理逻辑的正确性。

**测试改进：**

* 重新启用并优化了`task_struct.rs`中的内核任务测试，包括：
  - 基本内核任务创建测试：验证任务ID、内核线程状态、栈基地址及初始中断帧指针
  - 内核线程上下文初始化测试：验证栈指针、返回地址及程序计数器设置

**测试代码健壮性：**

* 重构 `timer.rs` 中计时器递增测试循环，改用显式计数变量的 `while` 循环，提升代码清晰度并避免编译器优化导致的循环跳过问题。