### PR TITLE
docs: 为mm模块撰写文档

### DIFF
--- a/document/mm/README.md
+++ b/document/mm/README.md
@@ -1,0 +1,240 @@
+# MM 子系统文档
+
+## 简介
+
+MM（Memory Management，内存管理）子系统是 Comix 内核的核心组件，负责管理系统的物理和虚拟内存。该子系统采用清晰的分层架构，将架构无关的抽象层与架构特定的实现层分离，支持 RISC-V 和 LoongArch 等多种硬件平台。
+
+### 主要功能
+
+- **物理内存管理**：物理帧的分配、回收和跟踪
+- **虚拟内存管理**：地址空间管理、页表操作、内存映射
+- **内核堆分配**：支持动态内存分配的全局分配器
+- **架构抽象**：统一的接口支持多种硬件架构
+
+## 模块结构
+
+```
+os/src/mm/                          # 架构无关的内存管理层
+│
+├── mod.rs ........................ MM 子系统初始化入口
+│
+├── address/ ...................... 地址抽象层
+│   ├── address.rs ............... 物理/虚拟地址类型 (Paddr/Vaddr)
+│   ├── page_num.rs .............. 物理/虚拟页号类型 (Ppn/Vpn)
+│   └── operations.rs ............ 地址运算 trait 定义
+│
+├── frame_allocator/ .............. 物理帧分配器
+│   └── frame_allocator.rs ....... 核心分配器及 RAII 包装器
+│
+├── global_allocator/ ............. 内核堆分配器
+│   ├── global_allocator.rs ...... talc 全局分配器实现
+│   └── heap.rs .................. C 风格 kmalloc 接口（未实现）
+│
+├── page_table/ ................... 页表抽象层
+│   ├── page_table.rs ............ PageTableInner trait 定义
+│   └── page_table_entry.rs ...... PTE trait 及通用标志位
+│
+└── memory_space/ ................. 地址空间管理
+    ├── memory_space.rs .......... MemorySpace 结构及空间创建
+    └── mapping_area.rs .......... MappingArea 映射区域管理
+
+os/src/arch/{riscv,loongarch}/mm/  # 架构特定实现层
+│
+├── mod.rs ........................ 地址转换函数
+├── page_table.rs ................. PageTableInner 实现
+└── page_table_entry.rs ........... PageTableEntry 实现
+```
+
+## 文档导航
+
+### 核心概念
+
+- **[整体架构](architecture.md)** - MM 子系统的分层设计、模块依赖关系和初始化流程
+
+### 子模块详解
+
+- **[地址抽象层](address.md)** - Paddr/Vaddr/Ppn/Vpn 类型、地址运算和范围操作（**左闭右开区间**）
+- **[物理帧分配器](frame_allocator.md)** - 水位线 + 回收栈分配策略、FrameTracker RAII 机制
+- **[全局堆分配器](global_allocator.md)** - talc 全局分配器实现和动态内存分配
+- **[页表抽象层](page_table.md)** - PageTableInner trait、RISC-V SV39 实现、UniversalPTEFlag
+
+### 地址空间管理
+
+- **[地址空间管理](memory_space.md)** - 地址空间管理、MemorySpace 结构、MappingArea 映射区域及系统调用支持
+
+### API 参考
+
+- **[API 索引](api_reference.md)** - 完整的公共 API 列表及文件位置
+
+## 设计原则
+
+### 1. 架构抽象
+
+MM 子系统使用 trait 系统实现架构抽象，架构特定代码必须实现以下接口：
+
+- `vaddr_to_paddr()` / `paddr_to_vaddr()` - 地址转换函数
+- `PageTableInner` trait - 页表操作接口
+- `PageTableEntry` trait - 页表项操作接口
+
+### 2. 安全性保障
+
+- **RAII 模式**：物理帧通过 `FrameTracker` 自动管理生命周期
+- **类型安全**：物理地址和虚拟地址使用不同类型，防止混用
+- **所有权系统**：利用 Rust 的所有权机制防止内存泄漏
+
+### 3. 性能优化
+
+- **帧回收优化**：回收栈自动合并连续帧，减少碎片
+- **直接映射**：内核空间使用直接映射，避免页表查找开销
+- **对齐分配**：支持对齐的连续帧分配，优化 DMA 等场景
+
+## 重要约定
+
+### Range 语义
+
+所有 range 类型均遵循 **左闭右开区间** 语义：
+
+- `AddressRange::new(start, end)` 表示区间 **[start, end)**
+- `PageNumRange::new(start, end)` 表示区间 **[start, end)**
+- 迭代器遍历时包含 `start`，不包含 `end`
+
+### 内存布局
+
+Comix 采用**高半核（Higher Half Kernel）**设计，虚拟地址空间分为两个主要区域：
+
+```
+虚拟地址空间布局（从高地址到低地址）:
+
+═══════════════════════════════════════════════════════════════════
+                        高半核（内核空间）
+═══════════════════════════════════════════════════════════════════
+0xFFFF_FFFF_FFFF_FFFF
+        |
+        ... (向高地址扩展的物理内存直接映射区)
+        |
+[可用物理内存帧]          ← [ekernel, MEMORY_END) 直接映射
+[内核堆 Heap]             ← sheap ~ eheap (16MB，talc 分配器)
+[内核 BSS 段 .bss]        ← sbss ~ ebss
+[内核数据段 .data]        ← sdata ~ edata
+[内核只读数据段 .rodata]  ← srodata ~ erodata
+[内核代码段 .text]        ← stext ~ etext
+        |
+0xFFFF_FFC0_8020_0000 ← VIRTUAL_BASE (内核加载地址)
+        |
+0xFFFF_FFC0_0000_0000 ← VADDR_START (内核空间基址)
+
+物理地址映射: vaddr = paddr | 0xFFFF_FFC0_0000_0000
+
+═══════════════════════════════════════════════════════════════════
+                         低半核（用户空间）
+═══════════════════════════════════════════════════════════════════
+0xFFFF_FFFF_FFFF_FFFF
+        |
+[TRAMPOLINE]              ← usize::MAX - PAGE_SIZE + 1
+[GUARD_PAGE]              ← 未映射的保护页
+[TRAP_CONTEXT]            ← TRAMPOLINE - 2 * PAGE_SIZE
+[GUARD_PAGE]              ← 未映射的保护页
+[USER_STACK]              ← 用户栈区域 (4MB)
+        |
+        ... (动态扩展空间)
+        |
+[USER_HEAP]               ← 用户堆区域（可动态扩展，最大 64MB）
+[USER_DATA]               ← 用户数据段 (.data, .bss)
+[USER_TEXT]               ← 用户代码段 (.text)
+        |
+0x0000_0000_0000_0000
+```
+
+**关键地址常量**：
+
+*内核空间*：
+- `VADDR_START = 0xFFFF_FFC0_0000_0000` - 内核虚拟地址空间基址（RISC-V）
+- `VIRTUAL_BASE = 0xFFFF_FFC0_8020_0000` - 内核实际加载地址
+- `PHYSICAL_BASE = 0x8020_0000` - 内核物理加载地址
+- `MEMORY_END = 0x8800_0000` - 物理内存结束地址（128MB，QEMU virt）
+
+*用户空间*：
+- `TRAMPOLINE = usize::MAX - PAGE_SIZE + 1` - 跳板页地址
+- `TRAP_CONTEXT = TRAMPOLINE - 2 * PAGE_SIZE` - 陷阱上下文地址
+- `USER_STACK_TOP = TRAP_CONTEXT - PAGE_SIZE` - 用户栈顶
+
+**地址转换规则**（RISC-V SV39）：
+- 物理地址 → 虚拟地址：`vaddr = paddr | VADDR_START`
+- 虚拟地址 → 物理地址：`paddr = vaddr & 0x0000_003F_FFFF_FFFF`
+
+## 快速开始
+
+### 初始化流程
+
+MM 子系统在 `mm::init()` 中按以下顺序初始化：
+
+1. **物理帧分配器初始化** - 管理 `[ekernel, MEMORY_END)` 物理内存区域
+2. **内核堆分配器初始化** - 初始化全局堆分配器
+3. **内核地址空间创建** - 创建并激活内核页表
+
+```rust
+// os/src/mm/mod.rs:33
+pub fn init() {
+    // 1. 初始化物理帧分配器
+    let ekernel_paddr = unsafe { vaddr_to_paddr(ekernel as usize) };
+    init_frame_allocator(Ppn::from_addr_ceil(ekernel_paddr),
+                         Ppn::from_addr_floor(MEMORY_END));
+
+    // 2. 初始化堆分配器
+    init_heap();
+
+    // 3. 创建并激活内核地址空间
+    #[cfg(target_arch = "riscv64")] {
+        let root_ppn = with_kernel_space(|space| space.root_ppn());
+        crate::arch::mm::PageTableInner::activate(root_ppn);
+    }
+}
+```
+
+### 常见操作示例
+
+#### 分配物理帧
+
+```rust
+use crate::mm::frame_allocator::alloc_frame;
+
+// 分配单个物理帧（自动释放）
+let frame = alloc_frame().expect("Failed to allocate frame");
+let ppn = frame.ppn();
+```
+
+#### 创建地址映射
+
+```rust
+use crate::mm::memory_space::MemorySpace;
+
+// 创建用户地址空间
+let mut space = MemorySpace::from_elf(elf_data);
+
+// 映射匿名内存
+space.mmap(start_vaddr, len, prot);
+```
+
+#### 地址转换
+
+```rust
+use crate::mm::address::{Vaddr, Paddr};
+
+// 虚拟地址转物理地址
+let vaddr = Vaddr::new(0xffff_ffc0_8000_0000);
+let paddr = vaddr.to_paddr();
+
+// 物理地址转虚拟地址
+let vaddr_back = paddr.to_vaddr();
+```
+
+## 相关资源
+
+- **源代码位置**：`os/src/mm/` 和 `os/src/arch/{riscv,loongarch}/mm/`
+- **配置常量**：`os/src/config.rs`
+
+## 版本信息
+
+- **Rust 版本**：nightly-2025-01-13
+- **支持架构**：RISC-V (SV39), LoongArch (TODO)
+- **页面大小**：4KB（大页支持已暂时禁用）

--- a/document/mm/address.md
+++ b/document/mm/address.md
@@ -1,0 +1,353 @@
+# 地址抽象层
+
+## 概述
+
+地址抽象层提供了类型安全的物理地址和虚拟地址抽象，以及页号（Page Number）的相关操作。通过 `repr(transparent)` 实现零成本抽象，同时提供编译期类型安全保证。
+
+### 设计目标
+
+1. **类型安全**：物理地址和虚拟地址使用不同类型，防止混用
+2. **零成本抽象**：通过 `repr(transparent)` 保证与 usize 相同的内存布局
+3. **便捷操作**：提供丰富的算术运算、对齐操作和范围查询
+4. **架构无关**：地址转换逻辑委托给架构特定层
+
+### 核心类型
+
+```rust
+// 物理地址和虚拟地址
+#[repr(transparent)]
+pub struct Paddr(usize);
+
+#[repr(transparent)]
+pub struct Vaddr(usize);
+
+// 物理页号和虚拟页号
+#[repr(transparent)]
+pub struct Ppn(usize);
+
+#[repr(transparent)]
+pub struct Vpn(usize);
+
+// 地址范围（左闭右开区间）
+pub struct AddressRange<T: Address> {
+    start: T,  // 包含
+    end: T,    // 不包含
+}
+
+pub type PaddrRange = AddressRange<Paddr>;
+pub type VaddrRange = AddressRange<Vaddr>;
+pub type PpnRange = AddressRange<Ppn>;
+pub type VpnRange = AddressRange<Vpn>;
+```
+
+## 地址类型 (Paddr/Vaddr)
+
+### 基本操作
+
+```rust
+// 创建地址
+let paddr = Paddr::new(0x8000_0000);
+let vaddr = Vaddr::new(0xffff_ffc0_8000_0000);
+
+// 转换为 usize
+let addr_val: usize = paddr.as_usize();
+
+// 地址转换
+let vaddr = paddr.to_vaddr();  // 物理 → 虚拟
+let paddr = vaddr.to_paddr();  // 虚拟 → 物理（unsafe）
+```
+
+### 算术运算
+
+```rust
+// 基于类型大小的运算
+let addr = Vaddr::new(0x1000);
+let addr2 = addr.add::<u64>(3);  // 0x1000 + 3 * 8 = 0x1018
+
+// 单步前进/后退
+let next = addr.step();       // 0x1001
+let prev = addr.step_back();  // 0x0fff
+
+// 运算符重载
+let sum = addr1 + addr2;      // 加法
+let diff = addr1 - addr2;     // 减法
+let aligned = addr1 & mask;   // 位与（用于对齐）
+```
+
+### 对齐操作
+
+```rust
+let addr = Vaddr::new(0x1234);
+
+// 按任意对齐值对齐
+let up = addr.align_up(16);       // 0x1240
+let down = addr.align_down(16);   // 0x1230
+assert!(addr.is_aligned(16));     // false
+
+// 按页对齐（PAGE_SIZE = 4096）
+let page_aligned = addr.align_up_to_page();  // 0x2000
+assert!(page_aligned.is_page_aligned());     // true
+```
+
+### 地址范围
+
+```rust
+// 创建范围 [0x1000, 0x5000)
+let range = VaddrRange::new(
+    Vaddr::new(0x1000),
+    Vaddr::new(0x5000)
+);
+
+// 长度和边界
+assert_eq!(range.len(), 0x4000);
+assert_eq!(range.start(), Vaddr::new(0x1000));
+assert_eq!(range.end(), Vaddr::new(0x5000));
+
+// 包含关系（注意：左闭右开）
+assert!(range.contains(&Vaddr::new(0x1000)));   // 包含 start
+assert!(!range.contains(&Vaddr::new(0x5000)));  // 不包含 end
+
+// 区间运算
+let r1 = VaddrRange::new(Vaddr::new(0x1000), Vaddr::new(0x3000));
+let r2 = VaddrRange::new(Vaddr::new(0x2000), Vaddr::new(0x4000));
+
+if r1.intersects(&r2) {
+    let inter = r1.intersection(&r2).unwrap();  // [0x2000, 0x3000)
+}
+
+let union = r1.union(&r2).unwrap();  // [0x1000, 0x4000)
+```
+
+## 页号类型 (Ppn/Vpn)
+
+### 地址与页号转换
+
+```rust
+// 地址 → 页号
+let addr = Paddr::new(0x8000_1234);
+let ppn_floor = Ppn::from_addr_floor(addr);  // 向下取整：0x8000_1234 / 4096
+let ppn_ceil = Ppn::from_addr_ceil(addr);    // 向上取整
+
+// 页号 → 地址
+let vpn = Vpn::new(0x100);
+let start_addr = vpn.start_addr();  // 页起始地址：0x100 * 4096
+let end_addr = vpn.end_addr();      // 下一页起始地址：0x101 * 4096
+```
+
+### 页号运算
+
+```rust
+let ppn = Ppn::new(0x8000_1);
+
+// 步进
+let next_ppn = ppn.step();       // 0x8000_2
+let prev_ppn = ppn.step_back();  // 0x8000_0
+
+// 偏移
+let offset_ppn = ppn.offset(10);  // 0x8000_b
+```
+
+### 页号范围
+
+```rust
+// 创建范围 [0x10, 0x20)
+// 注意：左闭右开
+let range = VpnRange::new(Vpn::new(0x10), Vpn::new(0x20));
+
+assert_eq!(range.len(), 0x10);  // 包含 16 个页
+
+// 迭代页号
+for vpn in range {
+    println!("VPN: {:#x}", vpn.as_usize());
+}
+// 输出：0x10, 0x11, ..., 0x1f（不包含 0x20）
+```
+
+## 地址运算 Trait
+
+地址类型通过以下 trait 提供统一的操作接口：
+
+### UsizeConvert
+
+```rust
+pub trait UsizeConvert {
+    fn as_usize(&self) -> usize;
+    fn from_usize(value: usize) -> Self;
+}
+```
+
+### CalcOps
+
+提供算术和位运算：
+
+```rust
+// 支持的运算符
+addr1 + addr2   // 加法
+addr1 - addr2   // 减法
+addr1 & mask    // 位与
+addr1 | mask    // 位或
+addr1 ^ mask    // 位异或
+addr1 >> n      // 右移
+addr1 << n      // 左移
+```
+
+### AlignOps
+
+提供对齐操作：
+
+```rust
+pub trait AlignOps {
+    fn is_aligned(&self, align: usize) -> bool;
+    fn align_up(&self, align: usize) -> Self;
+    fn align_down(&self, align: usize) -> Self;
+    fn is_page_aligned(&self) -> bool;
+    fn align_up_to_page(&self) -> Self;
+    fn align_down_to_page(&self) -> Self;
+}
+```
+
+## 使用场景
+
+### 场景 1：内核地址空间映射
+
+```rust
+extern "C" {
+    fn stext();
+    fn etext();
+}
+
+// 获取 .text 段地址范围
+let text_start = Vaddr::new(stext as usize);
+let text_end = Vaddr::new(etext as usize);
+
+// 创建映射区域
+space.push(MappingArea::new(
+    VaddrRange::new(text_start, text_end),
+    MapType::Direct,
+    UniversalPTEFlag::kernel_r() | UniversalPTEFlag::X,
+    AreaType::KernelText,
+));
+```
+
+### 场景 2：物理帧分配器初始化
+
+```rust
+// 计算可用物理内存范围
+let ekernel_paddr = unsafe { vaddr_to_paddr(ekernel as usize) };
+let start = Ppn::from_addr_ceil(Paddr::new(ekernel_paddr));
+let end = Ppn::from_addr_floor(Paddr::new(MEMORY_END));
+
+// 初始化分配器
+init_frame_allocator(start, end);
+```
+
+### 场景 3：拷贝数据到物理页
+
+```rust
+pub fn copy_data(&self, page_table: &ActivePageTableInner, data: &[u8]) {
+    let mut offset = 0;
+    for vpn in self.vpn_range {
+        // 翻译虚拟地址到物理地址
+        let paddr = page_table.translate(vpn.start_addr()).unwrap();
+
+        // 转换为可访问的虚拟地址
+        let vaddr = paddr.to_vaddr();
+
+        // 拷贝数据
+        let dst = unsafe {
+            core::slice::from_raw_parts_mut(vaddr.as_usize() as *mut u8, PAGE_SIZE)
+        };
+        let len = core::cmp::min(PAGE_SIZE, data.len() - offset);
+        dst[..len].copy_from_slice(&data[offset..offset + len]);
+        offset += len;
+    }
+}
+```
+
+## 常见错误
+
+### 错误 1：忘记 Range 是左闭右开
+
+```rust
+// ❌ 错误：期望包含结束地址
+let range = VaddrRange::new(start_addr, end_addr);
+assert!(range.contains(&end_addr));  // 断言失败！
+
+// ✅ 正确：end 应为 end_addr.step()
+let range = VaddrRange::new(start_addr, end_addr.step());
+assert!(range.contains(&end_addr));  // 通过
+```
+
+### 错误 2：混用物理地址和虚拟地址
+
+```rust
+// ❌ 编译错误
+let paddr = Paddr::new(0x8000_0000);
+let vaddr: Vaddr = paddr;  // 类型不匹配！
+
+// ✅ 正确：显式转换
+let vaddr = paddr.to_vaddr();
+```
+
+### 错误 3：未检查对齐
+
+```rust
+// ❌ 页表根地址未对齐可能导致硬件异常
+let root_ppn = Ppn::from_addr_floor(paddr);
+
+// ✅ 应先检查对齐
+assert!(paddr.is_page_aligned());
+let root_ppn = Ppn::from_addr_floor(paddr);
+```
+
+### 错误 4：对齐值不是 2 的幂
+
+```rust
+// ❌ 错误：对齐值必须是 2 的幂
+let addr = Vaddr::new(0x1234);
+let aligned = addr.align_up(15);  // 15 不是 2 的幂
+
+// ✅ 正确：使用 2 的幂作为对齐值
+let aligned = addr.align_up(16);  // 16 = 2^4
+```
+
+**原因**：对齐算法 `(value + align - 1) & !(align - 1)` 仅对 2 的幂有效。
+
+## 性能考量
+
+### 零成本抽象
+
+```rust
+use core::mem::{size_of, align_of};
+
+// 大小和对齐与 usize 相同
+assert_eq!(size_of::<Paddr>(), size_of::<usize>());
+assert_eq!(align_of::<Paddr>(), align_of::<usize>());
+```
+
+### 内联优化
+
+关键方法标记为 `#[inline]`，在 `release` 模式下会被内联，编译为零成本的机器指令：
+
+```rust
+#[inline]
+pub fn new(value: usize) -> Self { Self(value) }
+
+#[inline]
+pub fn as_usize(&self) -> usize { self.0 }
+
+#[inline]
+pub const fn align_up(&self, align: usize) -> Self { /* ... */ }
+```
+
+## 相关文档
+
+- [整体架构](architecture.md) - MM 子系统分层设计
+- [物理帧分配器](frame_allocator.md) - Ppn 的实际使用
+- [页表抽象层](page_table.md) - Vpn/Ppn 的页表映射
+- [API 参考](api_reference.md) - 快速 API 查询
+
+## 参考实现
+
+- **源代码**：`os/src/mm/address/`
+- **架构接口**：`os/src/arch/*/mm/mod.rs`（地址转换函数）

--- a/document/mm/api_reference.md
+++ b/document/mm/api_reference.md
@@ -1,0 +1,550 @@
+# MM 子系统 API 参考手册
+
+## 概述
+
+本文档提供 MM 子系统所有公共 API 的快速参考，按模块分类并标注源代码位置。
+
+## 初始化 API
+
+### mm::init()
+
+```rust
+pub fn init()
+```
+
+**功能**：初始化整个 MM 子系统
+
+**调用顺序**：
+1. 初始化物理帧分配器
+2. 初始化内核堆分配器
+3. 创建并激活内核地址空间
+
+**源代码**：`os/src/mm/mod.rs:33`
+
+**示例**：
+```rust
+fn rust_main() {
+    mm::init();  // 第一个调用
+    // 此后可以使用所有内存管理功能
+}
+```
+
+---
+
+## 地址抽象层 API (address/)
+
+### Paddr / Vaddr
+
+#### 创建
+
+```rust
+impl Paddr {
+    pub fn new(value: usize) -> Self
+    pub fn as_usize(&self) -> usize
+}
+```
+
+**源代码**：`os/src/mm/address/address.rs:20-53`
+
+#### 转换
+
+```rust
+impl Paddr {
+    pub fn to_vaddr(self) -> Vaddr                    // 物理→虚拟
+}
+
+impl Vaddr {
+    pub fn to_paddr(self) -> Paddr                    // 虚拟→物理（unsafe）
+}
+```
+
+#### 对齐
+
+```rust
+impl AlignOps for Paddr/Vaddr {
+    fn is_aligned(&self, align: usize) -> bool
+    fn align_up(&self, align: usize) -> Self
+    fn align_down(&self, align: usize) -> Self
+    fn is_page_aligned(&self) -> bool
+    fn align_up_to_page(&self) -> Self
+    fn align_down_to_page(&self) -> Self
+}
+```
+
+**源代码**：`os/src/mm/address/operations.rs:44-75`
+
+### Ppn / Vpn
+
+#### 创建
+
+```rust
+impl Ppn/Vpn {
+    pub fn new(value: usize) -> Self
+    pub fn from_addr_floor(addr: Paddr/Vaddr) -> Self  // 向下取整
+    pub fn from_addr_ceil(addr: Paddr/Vaddr) -> Self   // 向上取整
+}
+```
+
+**源代码**：`os/src/mm/address/page_num.rs:7-64`
+
+#### 地址转换
+
+```rust
+impl PageNum for Ppn/Vpn {
+    fn start_addr(self) -> Paddr/Vaddr    // 页起始地址
+    fn end_addr(self) -> Paddr/Vaddr      // 页结束地址（下一页起始）
+    fn step(self) -> Self                 // 前进一页
+    fn step_back(self) -> Self            // 后退一页
+    fn offset(self, offset: isize) -> Self // 偏移多页
+}
+```
+
+### AddressRange / PageNumRange
+
+#### 创建
+
+```rust
+impl<T> AddressRange<T>/PageNumRange<T> {
+    pub fn new(start: T, end: T) -> Self  // [start, end) 左闭右开
+    pub fn start(&self) -> T
+    pub fn end(&self) -> T
+    pub fn len(&self) -> usize
+    pub fn is_empty(&self) -> bool
+}
+```
+
+**源代码**：`os/src/mm/address/address.rs:141-233`、`os/src/mm/address/page_num.rs:93-185`
+
+#### 区间运算
+
+```rust
+pub fn contains(&self, item: &T) -> bool
+pub fn intersects(&self, other: &Self) -> bool
+pub fn intersection(&self, other: &Self) -> Option<Self>
+pub fn union(&self, other: &Self) -> Option<Self>
+```
+
+**重要**：所有 Range 类型均为**左闭右开区间 [start, end)**
+
+---
+
+## 物理帧分配器 API (frame_allocator/)
+
+### 分配
+
+```rust
+pub fn alloc_frame() -> FrameAllocResult<FrameTracker>
+pub fn alloc_frames(n: usize) -> FrameAllocResult<Vec<FrameTracker>>
+pub fn alloc_contig_frames(n: usize) -> FrameAllocResult<FrameRangeTracker>
+pub fn alloc_contig_frames_aligned(n: usize, align: usize) -> FrameAllocResult<FrameRangeTracker>
+```
+
+**源代码**：`os/src/mm/frame_allocator/frame_allocator.rs:219-236`
+
+**示例**：
+```rust
+// 单帧
+let frame = alloc_frame()?;
+
+// 10个非连续帧
+let frames = alloc_frames(10)?;
+
+// 256个连续帧（1MB）
+let contig = alloc_contig_frames(256)?;
+
+// 512个连续帧，2MB对齐
+let aligned = alloc_contig_frames_aligned(512, 512)?;
+```
+
+### FrameTracker
+
+```rust
+impl FrameTracker {
+    pub fn ppn(&self) -> Ppn
+    pub fn start_paddr(&self) -> Paddr
+    pub fn as_slice<T>(&self) -> &[T]
+    pub fn as_slice_mut<T>(&mut self) -> &mut [T]
+}
+```
+
+**源代码**：`os/src/mm/frame_allocator/frame_allocator.rs:24-71`
+
+**RAII**：自动释放（`Drop`）
+
+### FrameRangeTracker
+
+```rust
+impl FrameRangeTracker {
+    pub fn start_ppn(&self) -> Ppn
+    pub fn end_ppn(&self) -> Ppn
+    pub fn start_paddr(&self) -> Paddr
+    pub fn end_paddr(&self) -> Paddr
+    pub fn iter(&self) -> impl Iterator<Item = Ppn>
+}
+```
+
+**源代码**：`os/src/mm/frame_allocator/frame_allocator.rs:74-132`
+
+### 错误类型
+
+```rust
+pub enum FrameAllocError {
+    OutOfMemory,
+    InvalidAddress,
+    AlignmentError,
+}
+```
+
+---
+
+## 内核堆分配器 API (global_allocator/)
+
+### 初始化
+
+```rust
+pub fn init_heap()
+```
+
+**功能**：初始化全局堆分配器（16 MB）
+
+**源代码**：`os/src/mm/global_allocator/global_allocator.rs:35`
+
+### 使用
+
+初始化后自动支持 `alloc` crate：
+
+```rust
+use alloc::vec::Vec;
+use alloc::boxed::Box;
+use alloc::string::String;
+use alloc::collections::BTreeMap;
+
+let v = Vec::new();
+let b = Box::new(42);
+let s = String::from("hello");
+let m = BTreeMap::new();
+```
+
+---
+
+## 页表抽象层 API (page_table/)
+
+### PageTableInner trait
+
+```rust
+pub trait PageTableInner<T: PageTableEntry> {
+    // 常量
+    const LEVELS: usize;
+    const MAX_VA_BITS: usize;
+    const MAX_PA_BITS: usize;
+
+    // 生命周期
+    fn new() -> Self;
+    fn from_ppn(ppn: Ppn) -> Self;
+    fn activate(ppn: Ppn);
+    fn root_ppn(&self) -> Ppn;
+
+    // TLB管理
+    fn tlb_flush(vpn: Vpn);
+    fn tlb_flush_all();
+
+    // 映射操作
+    fn map(&mut self, vpn: Vpn, ppn: Ppn, page_size: PageSize,
+           flags: UniversalPTEFlag) -> PagingResult<()>;
+    fn unmap(&mut self, vpn: Vpn) -> PagingResult<()>;
+    fn remap(&mut self, vpn: Vpn, new_ppn: Ppn, page_size: PageSize,
+             flags: UniversalPTEFlag) -> PagingResult<()>;
+
+    // 查询
+    fn translate(&self, vaddr: Vaddr) -> Option<Paddr>;
+    fn walk(&self, vpn: Vpn) -> PagingResult<(Ppn, PageSize, UniversalPTEFlag)>;
+}
+```
+
+**源代码**：`os/src/mm/page_table/page_table.rs:5-52`
+
+### UniversalPTEFlag
+
+```rust
+impl UniversalPTEFlag {
+    // 基础标志
+    pub const V: Self;  // Valid
+    pub const R: Self;  // Readable
+    pub const W: Self;  // Writable
+    pub const X: Self;  // Executable
+    pub const U: Self;  // User
+    pub const G: Self;  // Global
+    pub const A: Self;  // Accessed
+    pub const D: Self;  // Dirty
+
+    // 预定义组合
+    pub fn user_read() -> Self;      // U | R | V
+    pub fn user_rw() -> Self;        // U | R | W | V
+    pub fn user_rx() -> Self;        // U | R | X | V
+    pub fn kernel_r() -> Self;       // R | V
+    pub fn kernel_rw() -> Self;      // R | W | V
+}
+```
+
+**源代码**：`os/src/mm/page_table/page_table_entry.rs:4-58`
+
+### PageSize
+
+```rust
+pub enum PageSize {
+    Size4K = 0x1000,
+    Size2M = 0x20_0000,    // 暂时禁用
+    Size1G = 0x4000_0000,  // 暂时禁用
+}
+```
+
+### PagingError
+
+```rust
+pub enum PagingError {
+    NotMapped,
+    AlreadyMapped,
+    InvalidAddress,
+    InvalidPageSize,
+    PermissionDenied,
+    PageTableFull,
+    FrameAllocationFailed,
+    // ... 更多
+}
+```
+
+**源代码**：`os/src/mm/page_table/mod.rs:23-44`
+
+---
+
+## 地址空间管理 API (memory_space/)
+
+### MemorySpace
+
+#### 创建
+
+```rust
+impl MemorySpace {
+    pub fn new_kernel() -> Self              // 创建内核地址空间
+    pub fn from_elf(elf_data: &[u8]) -> Self // 从ELF创建用户地址空间
+}
+```
+
+**源代码**：`os/src/mm/memory_space/memory_space.rs:203-458`
+
+#### 系统调用支持
+
+```rust
+pub fn brk(&mut self, new_end: Vaddr) -> SyscallResult<Vaddr>
+pub fn mmap(&mut self, start: Vaddr, len: usize, prot: usize) -> SyscallResult<Vaddr>
+pub fn munmap(&mut self, start: Vaddr, len: usize) -> SyscallResult<()>
+```
+
+#### 进程管理
+
+```rust
+pub fn clone_for_fork(&self) -> Self           // fork时深拷贝
+pub fn activate(&self)                          // 激活地址空间
+pub fn root_ppn(&self) -> Ppn                   // 获取根页表页号
+```
+
+### MappingArea
+
+#### 创建
+
+```rust
+impl MappingArea {
+    pub fn new(
+        vaddr_range: VaddrRange,
+        map_type: MapType,
+        permission: UniversalPTEFlag,
+        area_type: AreaType,
+    ) -> Self
+}
+```
+
+**源代码**：`os/src/mm/memory_space/mapping_area.rs:62-100`
+
+#### 映射类型
+
+```rust
+pub enum MapType {
+    Direct,   // 直接映射（内核）
+    Framed,   // 帧映射（用户）
+}
+
+pub enum AreaType {
+    KernelText,
+    KernelData,
+    UserText,
+    UserData,
+    UserStack,
+    UserHeap,
+    // ...
+}
+```
+
+#### 操作
+
+```rust
+pub fn map(&mut self, page_table: &mut ActivePageTableInner) -> PagingResult<()>
+pub fn unmap(&mut self, page_table: &mut ActivePageTableInner) -> PagingResult<()>
+pub fn copy_data(&self, page_table: &ActivePageTableInner, data: &[u8])
+pub fn extend(&mut self, page_table: &mut ActivePageTableInner,
+              new_end_vpn: Vpn) -> PagingResult<()>
+pub fn shrink(&mut self, page_table: &mut ActivePageTableInner,
+              new_end_vpn: Vpn) -> PagingResult<()>
+```
+
+**源代码**：`os/src/mm/memory_space/mapping_area.rs:113-626`
+
+---
+
+## 架构特定 API (arch/*/mm/)
+
+### RISC-V (arch/riscv/mm/)
+
+#### 地址转换
+
+```rust
+pub const unsafe fn vaddr_to_paddr(vaddr: usize) -> usize
+pub const fn paddr_to_vaddr(paddr: usize) -> usize
+```
+
+**源代码**：`os/src/arch/riscv/mm/mod.rs:8-15`
+
+#### 常量
+
+```rust
+pub const VADDR_START: usize = 0xffff_ffc0_0000_0000;
+pub const PADDR_MASK: usize = 0x0000_003f_ffff_ffff;
+```
+
+#### SV39 PageTableInner
+
+```rust
+impl PageTableInner<PageTableEntry> for PageTableInner {
+    const LEVELS: usize = 3;
+    const MAX_VA_BITS: usize = 39;
+    const MAX_PA_BITS: usize = 56;
+    // ... trait实现
+}
+```
+
+**源代码**：`os/src/arch/riscv/mm/page_table.rs:21-286`
+
+---
+
+## 配置常量 (config.rs)
+
+```rust
+// 基础配置
+pub const PAGE_SIZE: usize = 4096;
+pub const KERNEL_HEAP_SIZE: usize = 16 * 1024 * 1024;  // 16 MB
+pub const USER_STACK_SIZE: usize = 4 * 1024 * 1024;    // 4 MB
+pub const MAX_USER_HEAP_SIZE: usize = 64 * 1024 * 1024; // 64 MB
+
+// 内存布局
+pub const TRAMPOLINE: usize = usize::MAX - PAGE_SIZE + 1;
+pub const TRAP_CONTEXT: usize = TRAMPOLINE - 2 * PAGE_SIZE;
+pub const USER_STACK_TOP: usize = TRAP_CONTEXT - PAGE_SIZE;
+
+// 平台相关
+pub const MEMORY_END: usize = 0x88000000;  // 128 MB
+```
+
+**源代码**：`os/src/config.rs`
+
+---
+
+## 常用模式
+
+### 模式 1：分配并映射页面
+
+```rust
+use crate::mm::frame_allocator::alloc_frame;
+use crate::mm::page_table::PageSize;
+
+let frame = alloc_frame()?;
+let ppn = frame.ppn();
+page_table.map(vpn, ppn, PageSize::Size4K, UniversalPTEFlag::user_rw())?;
+frames.insert(vpn, TrackedFrames::Single(frame));
+```
+
+### 模式 2：创建用户地址空间
+
+```rust
+use crate::mm::memory_space::MemorySpace;
+
+let elf_data = load_elf_from_disk(path)?;
+let mut space = MemorySpace::from_elf(&elf_data);
+space.activate();
+```
+
+### 模式 3：扩展堆区域
+
+```rust
+let new_end = current_end + size;
+let new_end_vaddr = Vaddr::new(new_end);
+space.brk(new_end_vaddr)?;
+```
+
+### 模式 4：地址转换
+
+```rust
+// 虚拟地址 → 物理地址
+let vaddr = Vaddr::new(0xffff_ffc0_8000_1000);
+let paddr = page_table.translate(vaddr).unwrap();
+
+// 页号 → 地址
+let vpn = Vpn::new(0x100);
+let vaddr = vpn.start_addr();
+```
+
+---
+
+## 快速索引
+
+| 功能 | API | 源文件 |
+|------|-----|--------|
+| 初始化MM | `mm::init()` | `mm/mod.rs:33` |
+| 分配单帧 | `alloc_frame()` | `frame_allocator/frame_allocator.rs:219` |
+| 分配连续帧 | `alloc_contig_frames(n)` | `frame_allocator/frame_allocator.rs:223` |
+| 地址对齐 | `addr.align_up_to_page()` | `address/operations.rs:69` |
+| 页号转换 | `Ppn::from_addr_floor(paddr)` | `address/page_num.rs:34` |
+| 创建页表 | `PageTableInner::new()` | `arch/riscv/mm/page_table.rs:56` |
+| 映射页面 | `page_table.map(vpn, ppn, ...)` | `page_table/page_table.rs:35` |
+| 创建用户空间 | `MemorySpace::from_elf(data)` | `memory_space/memory_space.rs:353` |
+| 扩展堆 | `space.brk(new_end)` | `memory_space/memory_space.rs:461` |
+| 地址转换 | `vaddr.to_paddr()` | `address/address.rs:50` |
+
+---
+
+## 版本信息
+
+- **文档版本**：1.0
+- **Rust工具链**：nightly-2025-01-13
+- **支持架构**：RISC-V (SV39), LoongArch (TODO)
+- **页面大小**：4KB（大页支持已暂时禁用）
+
+---
+
+## 相关文档
+
+- **[总览](README.md)** - MM子系统简介和导航
+- **[架构设计](architecture.md)** - 分层架构和设计决策
+- **[地址抽象层](address/overview.md)** - Paddr/Vaddr/Ppn/Vpn详解
+- **[物理帧分配器](frame_allocator/overview.md)** - FrameAllocator详解
+- **[内核堆分配器](global_allocator/heap_allocator.md)** - talc全局分配器
+- **[页表抽象层](page_table/overview.md)** - PageTableInner trait
+- **[地址空间管理](memory_space/overview.md)** - MemorySpace详解
+
+## 在线文档
+
+完整的 rustdoc 文档：
+
+```bash
+cd os && cargo doc --open
+```
+
+生成的文档位于：`target/doc/os/mm/index.html`

--- a/document/mm/architecture.md
+++ b/document/mm/architecture.md
@@ -1,0 +1,534 @@
+# MM 子系统整体架构
+
+## 概述
+
+Comix 内核的 MM（Memory Management）子系统采用分层架构设计，将架构无关的通用抽象与架构特定的实现清晰分离。这种设计使得内核能够在不修改核心逻辑的情况下支持多种硬件架构（RISC-V、LoongArch 等）。
+
+## 分层架构
+
+### 架构层次图
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                      应用层                                  │
+│            (系统调用: mmap/munmap/brk 等)                     │
+└─────────────────────────┬───────────────────────────────────┘
+                          │
+┌─────────────────────────┴───────────────────────────────────┐
+│            架构无关层 (os/src/mm/)                            │
+│  ┌──────────────────────────────────────────────────────┐   │
+│  │  memory_space/  - MemorySpace 地址空间管理           │   │
+│  │                 - MappingArea 映射区域管理            │   │
+│  └────────────────┬─────────────────┬───────────────────┘   │
+│                   │                 │                        │
+│  ┌────────────────▼─────────────┐  ┌▼──────────────────┐   │
+│  │  page_table/                 │  │ frame_allocator/  │   │
+│  │  - PageTableInner trait      │  │ - FrameAllocator  │   │
+│  │  - PageTableEntry trait      │  │ - FrameTracker    │   │
+│  │  - UniversalPTEFlag          │  └───────────────────┘   │
+│  └──────────────┬───────────────┘                           │
+│                 │                 ┌──────────────────────┐  │
+│  ┌──────────────▼──────────────┐  │ global_allocator/   │  │
+│  │  address/                   │  │ - talc Allocator    │  │
+│  │  - Paddr/Vaddr              │  └──────────────────────┘  │
+│  │  - Ppn/Vpn                  │                             │
+│  │  - 地址运算 trait            │                             │
+│  └─────────────────────────────┘                             │
+└─────────────────────────┬───────────────────────────────────┘
+                          │
+┌─────────────────────────┴───────────────────────────────────┐
+│         架构特定层 (os/src/arch/{riscv,loongarch}/mm/)       │
+│  ┌──────────────────────────────────────────────────────┐   │
+│  │  - vaddr_to_paddr() / paddr_to_vaddr()               │   │
+│  │  - PageTableInner 实现 (如 RISC-V SV39)               │   │
+│  │  - PageTableEntry 实现 (如 SV39 PTE 格式)             │   │
+│  └──────────────────────────────────────────────────────┘   │
+└─────────────────────────┬───────────────────────────────────┘
+                          │
+┌─────────────────────────┴───────────────────────────────────┐
+│                      硬件层                                  │
+│       (MMU, TLB, 物理内存, SATP/PGDH 寄存器等)               │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### 各层职责
+
+#### 1. 架构无关层 (os/src/mm/)
+
+提供通用的内存管理抽象，不包含任何架构特定代码。
+
+**职责**：
+- 定义统一的地址类型和页号类型
+- 提供物理帧分配和回收算法
+- 实现地址空间管理和映射区域管理
+- 定义页表操作的 trait 接口
+- 管理内核堆分配器
+
+**关键设计**：
+- 使用 trait 定义架构无关接口
+- 通过条件编译引用架构特定实现
+- 所有公共 API 均在此层暴露
+
+#### 2. 架构特定层 (os/src/arch/{riscv,loongarch}/mm/)
+
+为特定硬件架构提供具体实现。
+
+**职责**：
+- 实现虚拟地址与物理地址的转换逻辑
+- 实现 PageTableInner trait（页表遍历、映射、TLB 管理等）
+- 实现 PageTableEntry trait（PTE 标志位操作）
+- 提供架构特定的常量和配置
+
+**当前支持架构**：
+- **RISC-V**：完整实现 SV39 三级页表
+- **LoongArch**：TODO（占位符已预留）
+
+## 模块依赖关系
+
+```
+                        ┌──────────────┐
+                        │   mm/mod.rs  │
+                        │  (初始化器)   │
+                        └───────┬──────┘
+                                │ init()
+                ┌───────────────┼───────────────┐
+                │               │               │
+                ▼               ▼               ▼
+        ┌───────────┐   ┌──────────┐   ┌──────────────┐
+        │frame_     │   │ global_  │   │memory_space  │
+        │allocator  │   │allocator │   │(内核空间)     │
+        └───────────┘   └──────────┘   └──────┬───────┘
+                │                              │
+                │         ┌────────────────────┘
+                │         │
+                ▼         ▼
+        ┌─────────────────────────┐
+        │    page_table/          │
+        │  (PageTableInner trait) │
+        └────────────┬────────────┘
+                     │
+                     ▼
+        ┌─────────────────────────┐
+        │    address/             │
+        │  (Paddr/Vaddr/Ppn/Vpn)  │
+        └────────────┬────────────┘
+                     │
+                     ▼
+        ┌─────────────────────────┐
+        │   arch/*/mm/            │
+        │  - vaddr_to_paddr()     │
+        │  - paddr_to_vaddr()     │
+        │  - PageTable 实现        │
+        └─────────────────────────┘
+```
+
+### 关键依赖路径
+
+1. **内存分配路径**：
+   ```
+   memory_space → mapping_area → frame_allocator → FrameTracker
+   ```
+
+2. **地址转换路径**：
+   ```
+   Vaddr/Paddr → arch::mm::{vaddr_to_paddr, paddr_to_vaddr}
+   ```
+
+3. **页表操作路径**：
+   ```
+   MemorySpace → PageTableInner trait → arch::mm::PageTableInner
+   ```
+
+4. **初始化路径**：
+   ```
+   mm::init() → frame_allocator::init() → global_allocator::init() → MemorySpace::new_kernel()
+   ```
+
+## 初始化流程
+
+### 启动序列
+
+```
+┌────────────────────────────────────────────────────────────┐
+│  1. 内核入口 (rust_main)                                    │
+└─────────────────────┬──────────────────────────────────────┘
+                      │
+                      ▼
+┌────────────────────────────────────────────────────────────┐
+│  2. mm::init()                                              │
+│     ├─ 获取可用物理内存范围 [ekernel, MEMORY_END)          │
+│     ├─ 初始化物理帧分配器                                   │
+│     ├─ 初始化内核堆分配器 (talc)                            │
+│     └─ 创建并激活内核地址空间                               │
+└─────────────────────┬──────────────────────────────────────┘
+                      │
+      ┌───────────────┼───────────────┐
+      │               │               │
+      ▼               ▼               ▼
+┌──────────┐  ┌──────────────┐  ┌──────────────────┐
+│ 物理帧   │  │  内核堆      │  │  内核页表        │
+│ 分配器   │  │  分配器      │  │  创建与激活      │
+│ 就绪     │  │  就绪        │  │  就绪            │
+└──────────┘  └──────────────┘  └──────────────────┘
+```
+
+### 详细步骤
+
+#### 第一步：物理帧分配器初始化
+
+```rust
+// os/src/mm/mod.rs:36-41
+let ekernel_paddr = unsafe { vaddr_to_paddr(ekernel as usize) };
+let start = Ppn::from_addr_ceil(Paddr::new(ekernel_paddr));
+let end = Ppn::from_addr_floor(Paddr::new(MEMORY_END));
+init_frame_allocator(start, end);
+```
+
+**作用**：
+- 计算内核结束地址到物理内存结束的可用区域
+- 初始化全局帧分配器 `FRAME_ALLOCATOR`
+- 此时可以开始分配物理帧
+
+#### 第二步：内核堆分配器初始化
+
+```rust
+// os/src/mm/mod.rs:44
+init_heap();
+```
+
+**作用**：
+- 初始化 talc 全局堆分配器
+- 注册内核堆区域 `[sheap, eheap)`（由链接脚本定义）
+- 此时可以使用 `alloc` crate 进行动态内存分配（Vec、Box 等）
+
+#### 第三步：内核地址空间创建
+
+```rust
+// os/src/mm/mod.rs:47-51
+#[cfg(target_arch = "riscv64")] {
+    let root_ppn = with_kernel_space(|space| space.root_ppn());
+    crate::arch::mm::PageTableInner::activate(root_ppn);
+}
+```
+
+**作用**：
+- 调用 `MemorySpace::new_kernel()` 创建内核地址空间
+- 映射内核各段（text/rodata/data/bss/heap）
+- 直接映射所有物理内存到高半核
+- 写入 SATP 寄存器并刷新 TLB，启用分页
+
+### 内核地址空间构建细节
+
+```
+MemorySpace::new_kernel() 执行以下映射:
+
+1. 跳板页 (Trampoline)
+   [usize::MAX-PAGE_SIZE+1, usize::MAX+1) → 跳板代码物理页
+
+2. 内核代码段 (.text)
+   [stext, etext) → 对应物理地址，权限: R+X
+
+3. 内核只读数据段 (.rodata)
+   [srodata, erodata) → 对应物理地址，权限: R
+
+4. 内核数据段 (.data)
+   [sdata, edata) → 对应物理地址，权限: R+W
+
+5. 内核栈段 (.bss.stack)
+   [boot_stack, boot_stack_top) → 对应物理地址，权限: R+W
+
+6. 内核 BSS 段 (.bss)
+   [sbss, ebss) → 对应物理地址，权限: R+W
+
+7. 内核堆段
+   [sheap, eheap) → 对应物理地址，权限: R+W
+
+8. 直接映射物理内存
+   [ekernel, MEMORY_END) → 对应物理地址，权限: R+W
+   (用于访问用户进程的物理页面)
+```
+
+## 架构抽象模式
+
+### 1. 条件编译导出
+
+通过 `#[cfg(target_arch = "...")]` 实现架构选择：
+
+```rust
+// os/src/arch/mod.rs:6-10
+#[cfg(target_arch = "loongarch64")]
+pub use self::loongarch::*;
+
+#[cfg(target_arch = "riscv64")]
+pub use riscv::*;
+```
+
+### 2. Trait 接口契约
+
+架构特定代码必须实现以下 trait：
+
+```rust
+// PageTableInner trait (os/src/mm/page_table/page_table.rs:5-52)
+pub trait PageTableInner<T: PageTableEntry> {
+    const LEVELS: usize;          // 页表级数（如 SV39 为 3）
+    const MAX_VA_BITS: usize;     // 虚拟地址位宽（如 SV39 为 39）
+    const MAX_PA_BITS: usize;     // 物理地址位宽（如 SV39 为 56）
+
+    // TLB 管理
+    fn tlb_flush(vpn: Vpn);
+    fn tlb_flush_all();
+
+    // 生命周期
+    fn new() -> Self;
+    fn from_ppn(ppn: Ppn) -> Self;
+    fn activate(ppn: Ppn);
+
+    // 核心操作
+    fn map(&mut self, vpn: Vpn, ppn: Ppn, page_size: PageSize,
+           flags: UniversalPTEFlag) -> PagingResult<()>;
+    fn unmap(&mut self, vpn: Vpn) -> PagingResult<()>;
+    fn translate(&self, vaddr: Vaddr) -> Option<Paddr>;
+    // ...更多方法
+}
+```
+
+### 3. 通用标志位转换
+
+通过 `UniversalPTEFlag` 实现架构无关的权限表示：
+
+```rust
+// os/src/mm/page_table/page_table_entry.rs:4-11
+pub struct UniversalPTEFlag(u8);
+
+impl UniversalPTEFlag {
+    // 低 8 位兼容 RISC-V SV39 格式
+    pub const V: Self = Self(1 << 0);  // Valid
+    pub const R: Self = Self(1 << 1);  // Readable
+    pub const W: Self = Self(1 << 2);  // Writable
+    pub const X: Self = Self(1 << 3);  // Executable
+    // ...
+}
+```
+
+架构特定的 PTE 标志位通过 `UniversalConvertableFlag` trait 转换：
+
+```rust
+// os/src/arch/riscv/mm/page_table_entry.rs:142-146
+impl UniversalConvertableFlag for SV39PTEFlags {
+    fn from_universal(flag: UniversalPTEFlag) -> Self {
+        Self::from_bits(flag.bits() & 0xff).unwrap()
+    }
+}
+```
+
+### 4. 地址转换函数
+
+每个架构必须提供地址转换函数：
+
+```rust
+// RISC-V 实现 (os/src/arch/riscv/mm/mod.rs:8-15)
+pub const VADDR_START: usize = 0xffff_ffc0_0000_0000;
+pub const PADDR_MASK: usize = 0x0000_003f_ffff_ffff;
+
+pub const unsafe fn vaddr_to_paddr(vaddr: usize) -> usize {
+    vaddr & PADDR_MASK  // 提取低 38 位
+}
+
+pub const fn paddr_to_vaddr(paddr: usize) -> usize {
+    paddr | VADDR_START  // 添加高半核前缀
+}
+```
+
+## 关键设计决策
+
+### 1. 为什么使用直接映射？
+
+**内核空间的直接映射设计**（物理地址 → 物理地址 + VADDR_START）：
+
+**优势**：
+- 访问物理内存无需页表查找，性能优秀
+- 简化内核代码，地址转换仅需位运算
+- 便于访问用户进程的物理页面（用于拷贝数据）
+
+**代价**：
+- 需要占用较大的虚拟地址空间（高半核）
+- 仅适用于 64 位架构
+
+### 2. 为什么分离 Paddr 和 Vaddr？
+
+**类型安全设计**：
+
+```rust
+#[repr(transparent)]
+pub struct Paddr(usize);
+
+#[repr(transparent)]
+pub struct Vaddr(usize);
+```
+
+**优势**：
+- 编译期防止物理地址和虚拟地址混用
+- 明确表达函数参数的地址类型语义
+- 通过 `repr(transparent)` 保证零成本抽象
+
+### 3. 为什么使用 RAII 管理物理帧？
+
+**FrameTracker 设计**：
+
+```rust
+// os/src/mm/frame_allocator/frame_allocator.rs:24-35
+pub struct FrameTracker {
+    ppn: Ppn,
+}
+
+impl Drop for FrameTracker {
+    fn drop(&mut self) {
+        dealloc_frame(self.ppn);
+    }
+}
+```
+
+**优势**：
+- 自动释放，防止内存泄漏
+- 配合 Rust 所有权系统，编译期检查
+- 支持通过 `clone()` 显式拷贝，避免意外共享
+
+### 4. 为什么暂时禁用大页？
+
+**当前限制**：
+- `PageSize::Size2M` 和 `PageSize::Size1G` 枚举存在但未启用
+- 映射区域的 extend/shrink 仅支持 4K 页
+
+**原因**：
+- 大页扩展/收缩逻辑复杂，需要拆分/合并页表项
+- 帧分配器需要支持对齐的大块分配
+- 需要更多测试验证正确性
+
+**未来计划**：
+- 代码中已预留大页相关逻辑（已注释）
+- 完善后可启用，优化 TLB 性能
+
+### 5. 为什么使用左闭右开区间？
+
+**Range 语义统一**：
+
+```rust
+// AddressRange/PageNumRange 均为 [start, end)
+let range = VpnRange::new(start_vpn, end_vpn);
+// 包含 start_vpn，不包含 end_vpn
+```
+
+**优势**：
+- 符合 Rust 标准库惯例（`a..b` 即 `[a, b)`）
+- 便于计算长度：`len = end - start`
+- 避免边界处理歧义
+
+## 架构扩展指南
+
+### 添加新架构支持
+
+**步骤**：
+
+1. **创建架构目录**：
+   ```
+   os/src/arch/{新架构}/mm/
+   ├── mod.rs
+   ├── page_table.rs
+   └── page_table_entry.rs
+   ```
+
+2. **实现地址转换函数**（`mod.rs`）：
+   ```rust
+   pub const unsafe fn vaddr_to_paddr(vaddr: usize) -> usize;
+   pub const fn paddr_to_vaddr(paddr: usize) -> usize;
+   ```
+
+3. **实现 PageTableEntry trait**（`page_table_entry.rs`）：
+   - 定义 PTE 结构体（如 `struct RV64PTE(u64)`）
+   - 实现 `PageTableEntry` trait 的所有方法
+   - 实现 `UniversalConvertableFlag` 转换
+
+4. **实现 PageTableInner trait**（`page_table.rs`）：
+   - 定义页表结构体（如 `struct PageTableInner`）
+   - 实现所有必需方法（map/unmap/translate/walk 等）
+   - 实现 TLB 管理和页表激活
+
+5. **更新架构选择器**（`os/src/arch/mod.rs`）：
+   ```rust
+   #[cfg(target_arch = "新架构")]
+   pub use self::新架构::*;
+   ```
+
+6. **添加测试**：
+   - 单元测试验证地址转换正确性
+   - 集成测试验证页表操作
+
+### 注意事项
+
+- 确保 `MAX_VA_BITS` 和 `MAX_PA_BITS` 常量正确
+- TLB 刷新操作必须正确实现（错误可能导致诡异 bug）
+- 大页支持可选，但需在 `is_huge()` 中正确检测
+- 参考 RISC-V 实现（`os/src/arch/riscv/mm/`）作为范例
+
+## 性能考量
+
+### 关键优化
+
+1. **帧分配器回收优化**：
+   - 回收时自动合并栈顶连续帧
+   - 减少碎片，提高分配连续帧的成功率
+
+2. **直接映射避免 TLB miss**：
+   - 内核访问物理内存时无需查页表
+   - 减少 TLB 压力
+
+3. **BTreeMap 存储帧映射**：
+   - `MappingArea` 使用 `BTreeMap<Vpn, TrackedFrames>`
+   - O(log n) 查找性能，支持范围查询
+
+4. **零拷贝地址转换**：
+   - `repr(transparent)` 确保地址类型无运行时开销
+   - 地址转换函数标记为 `const` 和 `inline`
+
+### 潜在瓶颈
+
+- **全局锁**：`FRAME_ALLOCATOR` 使用 `Mutex` 保护，高并发时可能成为瓶颈
+- **TLB 刷新**：频繁的 `unmap` 操作导致 TLB 失效
+- **页表遍历**：三级页表查找需要 3 次内存访问（可通过 TLB 缓存缓解）
+
+## 安全性
+
+### 关键安全机制
+
+1. **类型系统防护**：
+   - 物理地址和虚拟地址类型隔离
+   - 页表项权限通过 `UniversalPTEFlag` 显式指定
+
+2. **RAII 资源管理**：
+   - `FrameTracker` 自动释放物理帧
+   - `MappingArea` 在 Drop 时自动取消映射
+
+3. **所有权检查**：
+   - 页表所有权明确（`MemorySpace` 拥有页表）
+   - 帧所有权通过 `FrameTracker` 转移
+
+4. **保护页机制**：
+   - 用户栈和 trap 上下文间插入未映射页
+   - 栈溢出时触发缺页异常而非静默覆盖
+
+### 已知限制
+
+- **Unsafe 代码**：地址转换函数标记为 `unsafe`，调用者需保证地址有效性
+- **直接映射风险**：内核可直接访问所有物理内存，需小心处理指针
+- **未实现 ASLR**：地址空间布局固定，存在安全隐患
+
+## 参考资料
+
+- **RISC-V 特权架构规范**：SV39 页表格式定义
+- **LoongArch 架构手册**：待实现架构的参考
+- **Rust 嵌入式书**：裸机编程最佳实践
+- **xv6-riscv**：经典教学操作系统，内存管理参考
+
+## 总结
+
+Comix 的 MM 子系统通过清晰的分层架构和 trait 抽象，实现了高度模块化和可扩展的设计。架构无关层提供统一接口，架构特定层提供硬件适配，二者通过 trait 系统和条件编译无缝集成。该设计既保证了代码的可维护性，又为未来扩展（如 LoongArch 支持、大页功能）奠定了坚实基础。

--- a/document/mm/frame_allocator.md
+++ b/document/mm/frame_allocator.md
@@ -1,0 +1,441 @@
+# 物理帧分配器
+
+## 概述
+
+物理帧分配器（Frame Allocator）负责管理可用物理内存页面（帧）的分配和回收。采用**水位线 + 回收栈**的混合策略，平衡了分配效率和内存利用率。
+
+### 设计目标
+
+1. **高效分配**：O(1) 时间复杂度分配单帧和连续帧
+2. **自动回收**：通过 RAII 机制防止内存泄漏
+3. **减少碎片**：回收栈自动合并连续帧
+4. **支持对齐**：满足 DMA 等场景的对齐需求
+
+### 核心组件
+
+- **FrameAllocator**：全局分配器，管理物理帧池
+- **FrameTracker**：单帧 RAII 包装器
+- **FrameRangeTracker**：连续帧 RAII 包装器
+- **TrackedFrames**：统一的帧枚举类型
+
+## 分配器原理
+
+### 数据结构
+
+```rust
+pub struct FrameAllocator {
+    start: Ppn,           // 可分配区域起始页号
+    end: Ppn,             // 可分配区域结束页号（左闭右开）
+    cur: Ppn,             // 当前分配水位线
+    recycled: Vec<Ppn>,   // 回收栈（按升序存储已释放的页号）
+}
+```
+
+### 分配策略
+
+```
+物理内存布局:
+
+0x8000_0000                                    MEMORY_END
+    │                                              │
+    ▼                                              ▼
+    ┌──────────────┬───────────────────────────────┬─────┐
+    │  内核占用    │    可分配区域 [start, end)     │未用 │
+    └──────────────┴───────────────────────────────┴─────┘
+                    ↑                    ↑          ↑
+                  start                 cur        end
+
+分配顺序:
+1. 优先从回收栈分配（LIFO）
+2. 回收栈为空时从水位线分配
+3. 水位线递增
+```
+
+### 回收优化
+
+回收时自动检测并合并栈顶连续帧：
+
+```
+场景：按相反顺序释放连续帧
+
+初始: cur = 105, recycled = []
+
+1. dealloc_frame(104):
+   recycled = [104]
+   104 + 1 == 105 (cur) → 合并！
+   recycled = [], cur = 104
+
+2. dealloc_frame(103):
+   recycled = [103]
+   103 + 1 == 104 (cur) → 合并！
+   recycled = [], cur = 103
+
+最终: cur = 102, recycled = []  // 完全回收
+```
+
+## 核心 API
+
+### 单帧分配
+
+```rust
+// 分配单个物理帧
+let frame = alloc_frame()?;
+let ppn = frame.ppn();
+
+// 访问帧内存
+let bytes = frame.as_slice_mut::<u8>();
+bytes[0] = 0xff;
+
+// FrameTracker 离开作用域时自动释放
+```
+
+### 多帧分配（非连续）
+
+```rust
+// 分配 5 个帧（可能非连续）
+let frames = alloc_frames(5)?;
+
+for frame in &frames {
+    println!("Allocated PPN: {:#x}", frame.ppn().as_usize());
+}
+// frames 离开作用域时批量释放
+```
+
+### 连续帧分配
+
+```rust
+// 分配 256 个连续帧（1MB）
+let contig = alloc_contig_frames(256)?;
+
+assert_eq!(contig.len(), 256);
+let start_ppn = contig.start_ppn();
+let end_ppn = contig.end_ppn();  // 左闭右开
+
+// 遍历连续帧
+for ppn in contig.iter() {
+    println!("PPN: {:#x}", ppn.as_usize());
+}
+```
+
+### 对齐连续帧分配
+
+```rust
+// 分配 512 个 4KB 页（2MB），起始地址 2MB 对齐
+let ppn_per_2mb = 512;
+let huge_page = alloc_contig_frames_aligned(512, ppn_per_2mb)?;
+
+// 验证对齐
+assert_eq!(huge_page.start_ppn().as_usize() % ppn_per_2mb, 0);
+```
+
+## RAII 机制
+
+### FrameTracker
+
+单帧的 RAII 包装器，离开作用域时自动释放：
+
+```rust
+pub struct FrameTracker {
+    ppn: Ppn,
+}
+
+impl FrameTracker {
+    pub fn ppn(&self) -> Ppn { self.ppn }
+
+    // 访问帧内存
+    pub fn as_slice<T>(&self) -> &[T] { /* ... */ }
+    pub fn as_slice_mut<T>(&mut self) -> &mut [T] { /* ... */ }
+}
+
+impl Drop for FrameTracker {
+    fn drop(&mut self) {
+        dealloc_frame(self.ppn);  // 自动释放
+    }
+}
+
+impl Clone for FrameTracker {
+    fn clone(&self) -> Self {
+        // 克隆时分配新帧并拷贝内容
+        alloc_frame().unwrap()
+    }
+}
+```
+
+**使用示例**：
+
+```rust
+{
+    let frame = alloc_frame()?;
+    // 使用 frame
+}  // 自动释放
+
+// 避免过早释放
+fn wrong_usage() -> Result<(), FrameAllocError> {
+    // ❌ 错误：过早释放
+    let ppn = {
+        let frame = alloc_frame()?;
+        frame.ppn()
+    };  // frame 被释放
+    page_table.map(vpn, ppn, ...)?;  // 映射已释放的帧！
+
+    Ok(())
+}
+
+fn correct_usage() -> Result<(), FrameAllocError> {
+    // ✅ 正确：延长生命周期
+    let frame = alloc_frame()?;
+    let ppn = frame.ppn();
+    page_table.map(vpn, ppn, ...)?;
+    frames.push(frame);  // 存储以保持所有权
+
+    Ok(())
+}
+```
+
+### FrameRangeTracker
+
+连续帧的 RAII 包装器：
+
+```rust
+pub struct FrameRangeTracker {
+    start_ppn: Ppn,
+    end_ppn: Ppn,  // 左闭右开
+}
+
+impl FrameRangeTracker {
+    pub fn start_ppn(&self) -> Ppn { self.start_ppn }
+    pub fn end_ppn(&self) -> Ppn { self.end_ppn }
+    pub fn len(&self) -> usize { /* ... */ }
+
+    // 迭代所有页号
+    pub fn iter(&self) -> impl Iterator<Item = Ppn> { /* ... */ }
+}
+
+impl Drop for FrameRangeTracker {
+    fn drop(&mut self) {
+        // 批量释放所有连续帧
+        for ppn in self.iter() {
+            dealloc_frame(ppn);
+        }
+    }
+}
+```
+
+### TrackedFrames 枚举
+
+统一的帧枚举类型，用于映射区域：
+
+```rust
+pub enum TrackedFrames {
+    Single(FrameTracker),
+    Multiple(Vec<FrameTracker>),
+    Contiguous(FrameRangeTracker),
+}
+
+impl TrackedFrames {
+    pub fn count(&self) -> usize {
+        match self {
+            Self::Single(_) => 1,
+            Self::Multiple(v) => v.len(),
+            Self::Contiguous(r) => r.len(),
+        }
+    }
+
+    pub fn ppns(&self) -> impl Iterator<Item = Ppn> + '_ {
+        match self {
+            Self::Single(f) => /* ... */,
+            Self::Multiple(v) => /* ... */,
+            Self::Contiguous(r) => r.iter(),
+        }
+    }
+}
+```
+
+**使用场景**：
+
+```rust
+// MappingArea 中存储不同类型的帧
+pub struct MappingArea {
+    vpn_range: VpnRange,
+    frames: BTreeMap<Vpn, TrackedFrames>,  // 灵活存储
+    // ...
+}
+
+impl MappingArea {
+    pub fn push_single(&mut self, vpn: Vpn) {
+        let frame = alloc_frame().unwrap();
+        self.frames.insert(vpn, TrackedFrames::Single(frame));
+    }
+
+    pub fn push_contig(&mut self, vpn_range: VpnRange) {
+        let contig = alloc_contig_frames(vpn_range.len()).unwrap();
+        let start_vpn = vpn_range.start();
+        self.frames.insert(start_vpn, TrackedFrames::Contiguous(contig));
+    }
+}
+```
+
+## 初始化
+
+```rust
+// os/src/mm/mod.rs:36-41
+pub fn init() {
+    // 计算可用物理内存范围
+    let ekernel_paddr = unsafe { vaddr_to_paddr(ekernel as usize) };
+    let start = Ppn::from_addr_ceil(Paddr::new(ekernel_paddr));
+    let end = Ppn::from_addr_floor(Paddr::new(MEMORY_END));
+
+    // 初始化全局帧分配器
+    init_frame_allocator(start, end);
+}
+```
+
+## 错误处理
+
+```rust
+#[derive(Debug)]
+pub enum FrameAllocError {
+    OutOfMemory,     // 物理内存耗尽
+    InvalidAddress,  // 地址无效
+    AlignmentError,  // 对齐错误
+}
+
+pub type FrameAllocResult<T> = Result<T, FrameAllocError>;
+```
+
+**常见错误场景**：
+
+```rust
+// OutOfMemory：物理内存耗尽
+match alloc_frame() {
+    Ok(frame) => { /* 使用 frame */ },
+    Err(FrameAllocError::OutOfMemory) => {
+        panic!("Physical memory exhausted!");
+    }
+}
+
+// AlignmentError：对齐值不是 2 的幂
+let result = alloc_contig_frames_aligned(10, 15);  // 15 不是 2 的幂
+assert!(matches!(result, Err(FrameAllocError::AlignmentError)));
+```
+
+## 使用场景
+
+### 场景 1：页表创建
+
+```rust
+// 分配页表根页面
+let root_frame = alloc_frame()?;
+let root_ppn = root_frame.ppn();
+
+// 初始化页表
+let page_table = PageTableInner::from_ppn(root_ppn);
+
+// root_frame 需要保持所有权，直到页表销毁
+```
+
+### 场景 2：用户程序加载
+
+```rust
+pub fn load_elf(&mut self, elf_data: &[u8]) -> Result<(), ElfError> {
+    let elf = xmas_elf::ElfFile::new(elf_data)?;
+
+    for ph in elf.program_iter() {
+        if ph.get_type() != ProgramHeaderType::Load {
+            continue;
+        }
+
+        let start_vpn = Vpn::from_addr_floor(Vaddr::new(ph.virtual_addr() as usize));
+        let end_vpn = Vpn::from_addr_ceil(Vaddr::new(
+            (ph.virtual_addr() + ph.mem_size()) as usize
+        ));
+
+        // 为每个页分配物理帧
+        for vpn in VpnRange::new(start_vpn, end_vpn) {
+            let frame = alloc_frame()?;
+            let ppn = frame.ppn();
+
+            // 映射
+            self.page_table.map(vpn, ppn, PageSize::Size4K, flags)?;
+
+            // 拷贝数据
+            let dst = ppn.start_addr().to_vaddr().as_usize() as *mut u8;
+            // ...
+
+            // 存储 frame 以保持所有权
+            self.frames.insert(vpn, TrackedFrames::Single(frame));
+        }
+    }
+
+    Ok(())
+}
+```
+
+### 场景 3：DMA 缓冲区
+
+```rust
+// 分配 4MB DMA 缓冲区（1024 个 4KB 页，4MB 对齐）
+let dma_pages = 1024;
+let alignment = 1024;  // 4MB = 1024 * 4KB
+
+let dma_buffer = alloc_contig_frames_aligned(dma_pages, alignment)?;
+
+// 传递物理地址给 DMA 控制器
+let dma_paddr = dma_buffer.start_ppn().start_addr();
+configure_dma(dma_paddr.as_usize());
+```
+
+## 常见陷阱
+
+### 陷阱 1：忘记 forget
+
+```rust
+// ❌ 错误：重复释放
+pub fn manual_dealloc(frame: FrameTracker) {
+    dealloc_frame(frame.ppn());
+    // frame Drop 时会再次释放！
+}
+
+// ✅ 正确：手动释放后 forget
+pub fn manual_dealloc(frame: FrameTracker) {
+    dealloc_frame(frame.ppn());
+    core::mem::forget(frame);  // 防止 Drop
+}
+```
+
+### 陷阱 2：过早释放
+
+参见前文 FrameTracker 使用示例。
+
+### 陷阱 3：Clone 语义误解
+
+```rust
+// Clone 会分配新帧并拷贝内容
+let frame1 = alloc_frame()?;
+let frame2 = frame1.clone();  // 分配新帧！
+
+assert_ne!(frame1.ppn(), frame2.ppn());  // 不同的物理帧
+```
+
+## 调试技巧
+
+```rust
+// 查看分配器状态
+with_frame_allocator(|allocator| {
+    println!("Total frames: {}", allocator.end.as_usize() - allocator.start.as_usize());
+    println!("Allocated: {}", allocator.cur.as_usize() - allocator.start.as_usize());
+    println!("Recycled: {}", allocator.recycled.len());
+});
+```
+
+## 相关文档
+
+- [地址抽象层](address.md) - Ppn/Paddr 类型
+- [整体架构](architecture.md) - MM 子系统架构
+- [页表抽象层](page_table.md) - 帧的映射使用
+- [API 参考](api_reference.md) - 完整 API 列表
+
+## 参考实现
+
+- **源代码**：`os/src/mm/frame_allocator/`
+- **初始化**：`os/src/mm/mod.rs:36-41`

--- a/document/mm/global_allocator.md
+++ b/document/mm/global_allocator.md
@@ -1,0 +1,237 @@
+# 全局堆分配器
+
+## 概述
+
+全局堆分配器为内核提供动态内存分配能力，支持 Rust 标准库的 `alloc` crate（Vec、Box、String 等）。Comix 使用 **talc** 作为全局分配器实现。
+
+### 为什么选择 talc？
+
+- **无锁设计**：单核环境下性能优秀
+- **零依赖**：适合裸机环境
+- **灵活配置**：支持多种分配策略
+- **稳定性好**：经过充分测试
+
+## 实现
+
+### 全局分配器定义
+
+```rust
+use talc::{Talc, Span};
+
+#[global_allocator]
+static ALLOCATOR: Talck<spin::Mutex<()>, ClaimOnOom> = Talc::new(unsafe {
+    ClaimOnOom::new(Span::empty())
+}).lock();
+```
+
+### 初始化流程
+
+```rust
+// os/src/mm/global_allocator/global_allocator.rs:30-40
+pub fn init_heap() {
+    extern "C" {
+        fn sheap();
+        fn eheap();
+    }
+
+    let heap_start = sheap as usize;
+    let heap_size = eheap as usize - heap_start;
+
+    unsafe {
+        ALLOCATOR
+            .lock()
+            .claim(Span::new(heap_start as *mut u8, heap_start + heap_size as *mut u8))
+            .expect("Failed to initialize heap");
+    }
+}
+```
+
+**链接脚本定义**（`linker.ld`）：
+
+```ld
+sheap = .;
+. = . + 16M;  // KERNEL_HEAP_SIZE = 16MB
+eheap = .;
+```
+
+### 内存布局
+
+```
+内核虚拟地址空间:
+
+0xFFFF_FFC0_8020_0000 ← 内核加载地址
+        ↓
+[.text]
+[.rodata]
+[.data]
+[.bss]
+        ↓
+sheap ──────────┐
+                │
+     [Heap]     │ 16MB（KERNEL_HEAP_SIZE）
+                │
+eheap ──────────┘
+        ↓
+[物理内存直接映射区]
+```
+
+## 基本使用
+
+### Vec 动态数组
+
+```rust
+use alloc::vec::Vec;
+
+let mut v = Vec::new();
+for i in 0..100 {
+    v.push(i);
+}
+assert_eq!(v.len(), 100);
+```
+
+### Box 堆分配
+
+```rust
+use alloc::boxed::Box;
+
+// 分配单个值
+let b = Box::new(42);
+assert_eq!(*b, 42);
+
+// 分配数组
+let arr = Box::new([0u8; 4096]);
+```
+
+### String 字符串
+
+```rust
+use alloc::string::String;
+
+let mut s = String::from("Hello, ");
+s.push_str("Comix!");
+assert_eq!(s, "Hello, Comix!");
+```
+
+### BTreeMap 有序映射
+
+```rust
+use alloc::collections::BTreeMap;
+
+let mut map = BTreeMap::new();
+map.insert("key1", "value1");
+map.insert("key2", "value2");
+
+assert_eq!(map.get("key1"), Some(&"value1"));
+```
+
+## OOM 处理
+
+当堆内存耗尽时，`alloc_error_handler` 会被调用：
+
+```rust
+// os/src/mm/global_allocator/global_allocator.rs:50-55
+#[alloc_error_handler]
+fn alloc_error_handler(layout: core::alloc::Layout) -> ! {
+    panic!(
+        "Heap allocation failed: size = {}, align = {}",
+        layout.size(),
+        layout.align()
+    );
+}
+```
+
+## 常见错误
+
+### 错误 1：未初始化就使用
+
+```rust
+// ❌ 错误：在 mm::init() 之前使用 alloc
+pub fn rust_main() {
+    let v = Vec::new();  // panic: heap not initialized!
+    mm::init();
+}
+
+// ✅ 正确：先初始化
+pub fn rust_main() {
+    mm::init();
+    let v = Vec::new();  // OK
+}
+```
+
+### 错误 2：堆溢出
+
+```rust
+// 内核堆仅 16MB，注意避免过大分配
+let huge_vec: Vec<u8> = Vec::with_capacity(32 * 1024 * 1024);  // OOM!
+```
+
+**建议**：
+- 大块内存使用物理帧分配器
+- 控制动态数据结构的增长
+- 必要时增加 `KERNEL_HEAP_SIZE`
+
+### 错误 3：忘记 no_std 环境
+
+```rust
+// ❌ 错误：std::vec 在 no_std 中不可用
+use std::vec::Vec;  // 编译错误！
+
+// ✅ 正确：使用 alloc::vec
+extern crate alloc;
+use alloc::vec::Vec;
+```
+
+## 调试技巧
+
+### 追踪堆分配
+
+使用静态计数器追踪分配/释放：
+
+```rust
+use core::sync::atomic::{AtomicUsize, Ordering};
+
+static ALLOC_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+// 在分配器中
+unsafe impl GlobalAlloc for MyAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOC_COUNT.fetch_add(1, Ordering::Relaxed);
+        // ...
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        ALLOC_COUNT.fetch_sub(1, Ordering::Relaxed);
+        // ...
+    }
+}
+
+// 检查内存泄漏
+assert_eq!(ALLOC_COUNT.load(Ordering::Relaxed), 0, "Memory leak detected!");
+```
+
+## 性能考量
+
+### talc 特点
+
+- **分配策略**：First-fit with splitting
+- **时间复杂度**：O(n)（n 为空闲块数量）
+- **碎片管理**：自动合并相邻空闲块
+- **锁开销**：使用 `spin::Mutex`，单核下性能优秀
+
+### 优化建议
+
+1. **批量分配**：使用 `Vec::with_capacity` 预分配
+2. **对象池**：频繁分配/释放的对象考虑使用对象池
+3. **栈优先**：小对象优先使用栈分配
+
+## 相关文档
+
+- [物理帧分配器](frame_allocator.md) - 大块内存分配
+- [整体架构](architecture.md) - MM 子系统初始化流程
+- [配置常量](../../os/src/config.rs) - KERNEL_HEAP_SIZE
+
+## 参考资料
+
+- **talc 文档**：https://docs.rs/talc
+- **GlobalAlloc trait**：https://doc.rust-lang.org/core/alloc/trait.GlobalAlloc.html
+- **源代码**：`os/src/mm/global_allocator/`

--- a/document/mm/memory_space.md
+++ b/document/mm/memory_space.md
@@ -1,0 +1,448 @@
+# 地址空间管理
+
+## 概述
+
+地址空间管理是 MM 子系统的最高抽象层，负责管理整个虚拟地址空间的布局、映射区域和页表操作。每个进程拥有独立的虚拟地址空间，支持内核和用户态的内存隔离。
+
+### 设计目标
+
+1. **地址空间隔离**：每个进程拥有独立的虚拟地址空间
+2. **灵活的内存布局**：支持代码段、数据段、堆、栈等多种区域
+3. **按需分配**：延迟分配物理内存，节省资源
+4. **系统调用支持**：实现 brk、mmap、munmap 等内存管理系统调用
+
+## 核心结构
+
+### MemorySpace
+
+```rust
+pub struct MemorySpace {
+    page_table: ActivePageTableInner,    // 页表（管理虚拟→物理映射）
+    areas: Vec<MappingArea>,             // 映射区域列表
+    heap_top: Option<Vpn>,               // 用户堆顶（brk）
+}
+```
+
+### MappingArea
+
+```rust
+pub struct MappingArea {
+    vpn_range: VpnRange,                 // 虚拟页号范围 [start, end)
+    area_type: AreaType,                 // 区域类型（代码/数据/堆/栈）
+    map_type: MapType,                   // 映射策略（Direct/Framed）
+    permission: UniversalPTEFlag,        // 权限标志（R/W/X/U）
+    frames: BTreeMap<Vpn, TrackedFrames>,  // 物理帧映射（Framed 类型使用）
+}
+```
+
+## 映射策略
+
+### Direct 直接映射
+
+用于内核空间，虚拟地址直接对应物理地址：
+
+```
+虚拟地址                    物理地址
+0xFFFF_FFC0_8000_0000  ←→  0x8000_0000
+0xFFFF_FFC0_8000_1000  ←→  0x8000_1000
+
+特点:
+✓ 无需分配物理帧
+✓ 访问物理内存无需查页表
+✓ 仅用于内核空间
+```
+
+```rust
+// 实现
+for vpn in self.vpn_range {
+    let vaddr = vpn.start_addr();
+    let paddr = vaddr.to_paddr();
+    let ppn = Ppn::from_addr_floor(paddr);
+    page_table.map(vpn, ppn, PageSize::Size4K, self.permission)?;
+}
+```
+
+### Framed 帧映射
+
+用于用户空间，每个虚拟页分配独立的物理帧：
+
+```
+虚拟页号      物理页号
+VPN 0x1000  ←→  PPN 0x8234_5  (分配)
+VPN 0x1001  ←→  PPN 0x8456_7  (分配)
+
+特点:
+✓ 每个虚拟页分配独立物理帧
+✓ 物理内存可能不连续
+✓ 自动管理物理帧生命周期（RAII）
+```
+
+```rust
+// 实现
+for vpn in self.vpn_range {
+    let frame = alloc_frame()?;
+    let ppn = frame.ppn();
+    page_table.map(vpn, ppn, PageSize::Size4K, self.permission)?;
+    self.frames.insert(vpn, TrackedFrames::Single(frame));
+}
+```
+
+## 地址空间创建
+
+### 内核地址空间
+
+```rust
+pub fn new_kernel() -> Self {
+    let mut space = Self {
+        page_table: ActivePageTableInner::new(),
+        areas: Vec::new(),
+        heap_top: None,
+    };
+
+    // 1. 映射跳板页
+    space.map_trampoline();
+
+    // 2. 映射内核各段（Direct 映射）
+    space.map_kernel_text();    // .text   R+X
+    space.map_kernel_rodata();  // .rodata R
+    space.map_kernel_data();    // .data   R+W
+    space.map_kernel_bss();     // .bss    R+W
+    space.map_kernel_heap();    // heap    R+W
+
+    // 3. 直接映射物理内存
+    space.map_physical_memory();
+
+    space
+}
+```
+
+**内核段映射示例**：
+
+```rust
+// .text 段（只读可执行）
+let text_start = Vaddr::new(stext as usize);
+let text_end = Vaddr::new(etext as usize);
+space.push(MappingArea::new(
+    VaddrRange::new(text_start, text_end),
+    MapType::Direct,
+    UniversalPTEFlag::kernel_r() | UniversalPTEFlag::X,
+    AreaType::KernelText,
+));
+```
+
+### 用户地址空间
+
+```rust
+pub fn from_elf(elf_data: &[u8]) -> Self {
+    let mut space = Self {
+        page_table: ActivePageTableInner::new(),
+        areas: Vec::new(),
+        heap_top: None,
+    };
+
+    // 1. 解析 ELF 文件，映射各段（Framed 映射）
+    let elf = xmas_elf::ElfFile::new(elf_data).unwrap();
+    for program_header in elf.program_iter() {
+        if program_header.get_type() == Ok(xmas_elf::program::Type::Load) {
+            // 创建映射区域
+            let area = MappingArea::new(
+                vaddr_range,
+                MapType::Framed,
+                permission,
+                area_type,
+            );
+            // 拷贝数据到物理页
+            area.copy_data(&space.page_table, program_header.get_data(&elf).unwrap());
+            space.areas.push(area);
+        }
+    }
+
+    // 2. 映射用户栈
+    space.map_user_stack();
+
+    // 3. 映射 trap 上下文
+    space.map_trap_context();
+
+    // 4. 初始化堆
+    space.heap_top = Some(space.infer_heap_start());
+
+    space
+}
+```
+
+## 系统调用支持
+
+### brk - 堆扩展
+
+```rust
+pub fn brk(&mut self, new_end: Vaddr) -> SyscallResult<Vaddr> {
+    let new_end_vpn = Vpn::from_addr_ceil(new_end);
+    let current_end_vpn = self.heap_top.unwrap();
+
+    if new_end_vpn > current_end_vpn {
+        // 扩展堆
+        let heap_area = self.find_heap_area_mut()?;
+        heap_area.extend(&mut self.page_table, new_end_vpn)?;
+        self.heap_top = Some(new_end_vpn);
+    } else if new_end_vpn < current_end_vpn {
+        // 收缩堆
+        let heap_area = self.find_heap_area_mut()?;
+        heap_area.shrink(&mut self.page_table, new_end_vpn)?;
+        self.heap_top = Some(new_end_vpn);
+    }
+
+    Ok(new_end)
+}
+```
+
+**使用场景**：
+
+```rust
+// C 标准库 malloc 底层调用
+let old_brk = process.memory_space.brk(Vaddr::new(0))?;  // 获取当前堆顶
+let new_brk = old_brk + Vaddr::new(size);
+process.memory_space.brk(new_brk)?;  // 扩展堆
+```
+
+### mmap - 匿名内存映射
+
+```rust
+pub fn mmap(&mut self, start: Vaddr, len: usize, prot: usize) -> SyscallResult<Vaddr> {
+    let start_vpn = Vpn::from_addr_floor(start);
+    let end_vpn = Vpn::from_addr_ceil(start + Vaddr::new(len));
+
+    // 检查地址范围是否可用
+    self.check_range_available(VpnRange::new(start_vpn, end_vpn))?;
+
+    // 创建新的映射区域
+    let permission = Self::prot_to_pte_flags(prot);
+    let area = MappingArea::new(
+        VaddrRange::new(start, start + Vaddr::new(len)),
+        MapType::Framed,
+        permission,
+        AreaType::UserAnonymous,
+    );
+
+    // 映射到页表
+    area.map(&mut self.page_table)?;
+    self.areas.push(area);
+
+    Ok(start)
+}
+```
+
+**使用场景**：
+
+```rust
+// 用户程序请求匿名内存
+let addr = mmap(NULL, 4096, PROT_READ | PROT_WRITE,
+                MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+```
+
+### munmap - 取消映射
+
+```rust
+pub fn munmap(&mut self, start: Vaddr, len: usize) -> SyscallResult<()> {
+    let start_vpn = Vpn::from_addr_floor(start);
+    let end_vpn = Vpn::from_addr_ceil(start + Vaddr::new(len));
+    let unmap_range = VpnRange::new(start_vpn, end_vpn);
+
+    // 找到重叠的映射区域并取消映射
+    let mut areas_to_remove = Vec::new();
+    for (idx, area) in self.areas.iter().enumerate() {
+        if area.vpn_range.intersects(&unmap_range) {
+            areas_to_remove.push(idx);
+        }
+    }
+
+    // 取消映射并释放资源
+    for idx in areas_to_remove.iter().rev() {
+        let area = self.areas.remove(*idx);
+        area.unmap(&mut self.page_table)?;
+    }
+
+    Ok(())
+}
+```
+
+## 进程管理
+
+### fork 时的地址空间复制
+
+```rust
+pub fn clone_for_fork(&self) -> Self {
+    let mut new_space = Self {
+        page_table: ActivePageTableInner::new(),
+        areas: Vec::new(),
+        heap_top: self.heap_top,
+    };
+
+    // 深拷贝所有映射区域
+    for area in &self.areas {
+        let mut new_area = area.clone_structure();
+
+        // 拷贝物理页内容
+        for vpn in area.vpn_range {
+            if let Some(old_frame) = area.frames.get(&vpn) {
+                let new_frame = old_frame.clone();  // 分配新帧并拷贝数据
+                new_area.frames.insert(vpn, new_frame);
+            }
+        }
+
+        // 映射到新页表
+        new_area.map(&mut new_space.page_table)?;
+        new_space.areas.push(new_area);
+    }
+
+    new_space
+}
+```
+
+**写时复制（COW）优化**（未来改进）：
+
+fork 时共享物理页并标记为只读，写入时触发缺页异常再复制，可显著提升性能并减少内存占用。
+
+### 激活地址空间
+
+```rust
+pub fn activate(&self) {
+    let root_ppn = self.page_table.root_ppn();
+    ActivePageTableInner::activate(root_ppn);
+}
+```
+
+**使用场景**：
+
+```rust
+// 进程切换
+fn switch_to_process(process: &mut Process) {
+    process.memory_space.activate();  // 切换页表
+    // 跳转到用户态
+}
+```
+
+## 区域类型
+
+```rust
+pub enum AreaType {
+    KernelText,       // 内核代码段
+    KernelData,       // 内核数据段
+    KernelHeap,       // 内核堆
+    UserText,         // 用户代码段
+    UserData,         // 用户数据段
+    UserHeap,         // 用户堆
+    UserStack,        // 用户栈
+    UserAnonymous,    // 用户匿名映射（mmap）
+    Trampoline,       // 跳板页
+    TrapContext,      // Trap 上下文
+}
+```
+
+## 使用场景
+
+### 场景 1：创建新进程
+
+```rust
+// 从 ELF 文件加载程序
+let elf_data = load_elf_from_disk("/bin/hello")?;
+let memory_space = MemorySpace::from_elf(&elf_data);
+
+let process = Process {
+    memory_space,
+    // ... 其他字段
+};
+```
+
+### 场景 2：进程 fork
+
+```rust
+fn sys_fork() -> SyscallResult<Pid> {
+    let parent = current_process();
+    let child_space = parent.memory_space.clone_for_fork();
+
+    let child = Process {
+        memory_space: child_space,
+        parent: Some(parent.pid()),
+        // ... 其他字段
+    };
+
+    Ok(child.pid())
+}
+```
+
+### 场景 3：动态内存分配（brk）
+
+```rust
+fn sys_brk(new_brk: usize) -> SyscallResult<usize> {
+    let process = current_process_mut();
+    let new_end = Vaddr::new(new_brk);
+    process.memory_space.brk(new_end)?;
+    Ok(new_brk)
+}
+```
+
+### 场景 4：内存映射（mmap）
+
+```rust
+fn sys_mmap(start: usize, len: usize, prot: usize) -> SyscallResult<usize> {
+    let process = current_process_mut();
+    let start_vaddr = Vaddr::new(start);
+    let mapped_addr = process.memory_space.mmap(start_vaddr, len, prot)?;
+    Ok(mapped_addr.as_usize())
+}
+```
+
+## 常见问题
+
+### Q1: 内核和用户地址空间如何隔离？
+
+**A**: 通过虚拟地址范围和 U 标志位：
+- 内核空间：高半核（0xffff_ffc0_0000_0000 以上），U=0
+- 用户空间：低地址（0x0 开始），U=1
+- CPU 在用户态无法访问 U=0 的页面
+
+### Q2: fork 时为什么要深拷贝？
+
+**A**: 当前实现保证父子进程完全独立。未来可改用写时复制（COW）优化性能。
+
+### Q3: 如何防止用户程序访问内核内存？
+
+**A**: 两层保护：
+1. 页表权限：内核页面设置 U=0
+2. 地址检查：系统调用参数验证用户指针合法性
+
+### Q4: mmap 分配的地址范围如何选择？
+
+**A**: 当前实现要求用户指定地址。未来可实现地址分配器自动选择空闲区域。
+
+## 性能优化
+
+### TLB 刷新优化
+
+```rust
+// ✅ 高效：批量映射后一次性刷新
+for vpn in vpn_range {
+    area.map_single_page(vpn, &mut page_table)?;
+}
+PageTableInner::tlb_flush_all();
+```
+
+### 内存占用优化
+
+- 共享只读页面（代码段、只读数据）
+- 写时复制（COW）
+- 大页支持（减少页表级数）
+- 延迟分配（按需分配物理帧）
+
+## 相关文档
+
+- [地址抽象层](address.md) - Vaddr/Vpn 类型
+- [页表抽象层](page_table.md) - 页表操作接口
+- [物理帧分配器](frame_allocator.md) - 物理内存分配
+- [整体架构](architecture.md) - MM 子系统架构
+- [API 参考](api_reference.md) - API 快速查询
+
+## 参考实现
+
+- **源代码**：`os/src/mm/memory_space/`
+- **初始化**：`os/src/mm/mod.rs:47-51`（内核地址空间）

--- a/document/mm/page_table.md
+++ b/document/mm/page_table.md
@@ -1,0 +1,376 @@
+# 页表抽象层
+
+## 概述
+
+页表抽象层提供架构无关的页表操作接口，通过 trait 系统将通用逻辑与硬件特定实现分离。目前已实现 RISC-V SV39 三级页表。
+
+### 设计目标
+
+1. **架构抽象**：统一的 trait 接口支持多种架构
+2. **类型安全**：通过 Rust 类型系统防止错误操作
+3. **灵活标志位**：UniversalPTEFlag 屏蔽架构差异
+4. **易于扩展**：新增架构只需实现 trait
+
+## 核心接口
+
+### PageTableInner Trait
+
+页表的核心操作接口：
+
+```rust
+pub trait PageTableInner<T: PageTableEntry> {
+    // 架构常量
+    const LEVELS: usize;          // 页表级数（SV39 为 3）
+    const MAX_VA_BITS: usize;     // 虚拟地址位宽（SV39 为 39）
+    const MAX_PA_BITS: usize;     // 物理地址位宽（SV39 为 56）
+
+    // 生命周期管理
+    fn new() -> Self;
+    fn from_ppn(root_ppn: Ppn) -> Self;
+    fn activate(ppn: Ppn);
+
+    // TLB 管理
+    fn tlb_flush(vpn: Vpn);
+    fn tlb_flush_all();
+
+    // 核心操作
+    fn map(&mut self, vpn: Vpn, ppn: Ppn, page_size: PageSize,
+           flags: UniversalPTEFlag) -> PagingResult<()>;
+    fn unmap(&mut self, vpn: Vpn) -> PagingResult<()>;
+    fn translate(&self, vaddr: Vaddr) -> Option<Paddr>;
+
+    // 查询操作
+    fn walk(&self, vpn: Vpn) -> PagingResult<(Ppn, PageSize, UniversalPTEFlag)>;
+    fn root_ppn(&self) -> Ppn;
+}
+```
+
+### UniversalPTEFlag
+
+架构无关的页表项标志位：
+
+```rust
+pub struct UniversalPTEFlag(u8);
+
+impl UniversalPTEFlag {
+    // 基础标志
+    pub const VALID: Self = Self(1 << 0);       // 页表项有效
+    pub const READABLE: Self = Self(1 << 1);    // 可读
+    pub const WRITABLE: Self = Self(1 << 2);    // 可写
+    pub const EXECUTABLE: Self = Self(1 << 3);  // 可执行
+    pub const USER_ACCESSIBLE: Self = Self(1 << 4);  // 用户态可访问
+    pub const GLOBAL: Self = Self(1 << 5);      // 全局映射
+    pub const ACCESSED: Self = Self(1 << 6);    // 已访问
+    pub const DIRTY: Self = Self(1 << 7);       // 已修改
+
+    // 组合标志
+    pub fn kernel_r() -> Self {
+        Self::VALID | Self::READABLE
+    }
+
+    pub fn kernel_rw() -> Self {
+        Self::VALID | Self::READABLE | Self::WRITABLE
+    }
+
+    pub fn kernel_rx() -> Self {
+        Self::VALID | Self::READABLE | Self::EXECUTABLE
+    }
+
+    pub fn user_r() -> Self {
+        Self::VALID | Self::READABLE | Self::USER_ACCESSIBLE
+    }
+
+    pub fn user_rw() -> Self {
+        Self::VALID | Self::READABLE | Self::WRITABLE | Self::USER_ACCESSIBLE
+    }
+
+    pub fn user_rwx() -> Self {
+        Self::VALID | Self::READABLE | Self::WRITABLE |
+        Self::EXECUTABLE | Self::USER_ACCESSIBLE
+    }
+}
+```
+
+## RISC-V SV39 实现
+
+### SV39 页表结构
+
+```
+39 位虚拟地址:
+┌─────────┬──────────┬──────────┬──────────┬────────────┐
+│ 63...39 │  38...30 │  29...21 │  20...12 │   11...0   │
+│ (符号位) │  VPN[2]  │  VPN[1]  │  VPN[0]  │   offset   │
+└─────────┴──────────┴──────────┴──────────┴────────────┘
+    25 位      9 位       9 位       9 位        12 位
+
+56 位物理地址:
+┌─────────┬──────────────────────────────┬────────────┐
+│ 55...44 │         43...12              │   11...0   │
+│ (保留)  │          PPN                 │   offset   │
+└─────────┴──────────────────────────────┴────────────┘
+   12 位             32 位                   12 位
+
+页表项 (PTE):
+┌────────┬──────────────────────┬───────┬─┬─┬─┬─┬─┬─┬─┬─┐
+│ 63...54│      53...10         │ 9...8 │D│A│G│U│X│W│R│V│
+│  (保留) │        PPN           │  RSW  │ │ │ │ │ │ │ │ │
+└────────┴──────────────────────┴───────┴─┴─┴─┴─┴─┴─┴─┴─┘
+  10 位          44 位              2 位   标志位（8位）
+```
+
+### 地址转换
+
+Comix 使用**直接映射**方式：
+
+```rust
+// 物理地址 → 虚拟地址
+pub const fn paddr_to_vaddr(paddr: usize) -> usize {
+    paddr | 0xffff_ffc0_0000_0000
+}
+
+// 虚拟地址 → 物理地址
+pub const unsafe fn vaddr_to_paddr(vaddr: usize) -> usize {
+    vaddr & 0x0000_003f_ffff_ffff
+}
+```
+
+### 页表遍历
+
+```
+三级页表查找流程:
+
+Virtual Address: VPN[2] | VPN[1] | VPN[0] | offset
+                   ↓
+┌──────────────────────────────────────┐
+│  Level 2 (Root Page Table)           │
+│  Entry[VPN[2]] → PPN of Level 1      │──┐
+└──────────────────────────────────────┘  │
+                                           ↓
+┌──────────────────────────────────────┐
+│  Level 1 Page Table                  │
+│  Entry[VPN[1]] → PPN of Level 0      │──┐
+└──────────────────────────────────────┘  │
+                                           ↓
+┌──────────────────────────────────────┐
+│  Level 0 Page Table (Leaf)           │
+│  Entry[VPN[0]] → PPN of Data Page    │──┐
+└──────────────────────────────────────┘  │
+                                           ↓
+                                 Physical Page + offset
+```
+
+### TLB 管理
+
+```rust
+// 刷新单个页
+pub fn tlb_flush(vpn: Vpn) {
+    unsafe {
+        asm!("sfence.vma {0}, zero", in(reg) vpn.as_usize());
+    }
+}
+
+// 刷新所有页
+pub fn tlb_flush_all() {
+    unsafe {
+        asm!("sfence.vma");
+    }
+}
+```
+
+## 基本使用
+
+### 创建页表
+
+```rust
+// 创建新页表（自动分配根页表帧）
+let mut page_table = ActivePageTableInner::new();
+
+// 从已有根页号创建
+let page_table = PageTableInner::from_ppn(root_ppn);
+```
+
+### 映射页面
+
+```rust
+// 映射单个 4K 页
+let vpn = Vpn::new(0x1000);
+let ppn = Ppn::new(0x8000_1);
+page_table.map(
+    vpn,
+    ppn,
+    PageSize::Size4K,
+    UniversalPTEFlag::user_rw()
+)?;
+
+// TLB 刷新
+ActivePageTableInner::tlb_flush(vpn);
+```
+
+### 取消映射
+
+```rust
+page_table.unmap(vpn)?;
+ActivePageTableInner::tlb_flush(vpn);
+```
+
+### 地址翻译
+
+```rust
+let vaddr = Vaddr::new(0x1000_0000);
+if let Some(paddr) = page_table.translate(vaddr) {
+    println!("VA {:#x} → PA {:#x}", vaddr.as_usize(), paddr.as_usize());
+} else {
+    println!("Page fault: unmapped address");
+}
+```
+
+### 查询映射信息
+
+```rust
+match page_table.walk(vpn) {
+    Ok((ppn, size, flags)) => {
+        println!("Mapped: VPN {:#x} → PPN {:#x}", vpn.as_usize(), ppn.as_usize());
+        println!("Page size: {:?}", size);
+        println!("Flags: {:?}", flags);
+    }
+    Err(e) => println!("Walk failed: {:?}", e),
+}
+```
+
+## 使用场景
+
+### 场景 1：内核地址空间创建
+
+```rust
+pub fn new_kernel() -> Self {
+    let mut space = MemorySpace::new();
+
+    // 映射跳板页
+    space.map_trampoline();
+
+    // 映射内核段
+    space.push(MappingArea::new(
+        VaddrRange::new(Vaddr::new(stext as usize), Vaddr::new(etext as usize)),
+        MapType::Direct,
+        UniversalPTEFlag::kernel_rx(),
+        AreaType::KernelText,
+    ));
+
+    // 映射内核数据段
+    space.push(MappingArea::new(
+        VaddrRange::new(Vaddr::new(sdata as usize), Vaddr::new(edata as usize)),
+        MapType::Direct,
+        UniversalPTEFlag::kernel_rw(),
+        AreaType::KernelData,
+    ));
+
+    // 直接映射物理内存
+    let phys_mem_end = paddr_to_vaddr(MEMORY_END);
+    space.push(MappingArea::new(
+        VaddrRange::new(Vaddr::new(ekernel as usize), Vaddr::new(phys_mem_end)),
+        MapType::Direct,
+        UniversalPTEFlag::kernel_rw(),
+        AreaType::PhysicalMemory,
+    ));
+
+    space
+}
+```
+
+### 场景 2：用户程序加载
+
+```rust
+pub fn from_elf(elf_data: &[u8]) -> Result<Self, ElfError> {
+    let elf = xmas_elf::ElfFile::new(elf_data)?;
+    let mut space = MemorySpace::new();
+
+    for ph in elf.program_iter() {
+        if ph.get_type() != ProgramHeaderType::Load {
+            continue;
+        }
+
+        let start_va = ph.virtual_addr() as usize;
+        let end_va = (ph.virtual_addr() + ph.mem_size()) as usize;
+        let flags = ph_flags_to_universal(ph.flags());
+
+        // 创建映射区域
+        let area = MappingArea::new(
+            VaddrRange::new(Vaddr::new(start_va), Vaddr::new(end_va)),
+            MapType::Framed,  // 为每页分配物理帧
+            flags,
+            AreaType::UserData,
+        );
+
+        space.push(area);
+    }
+
+    Ok(space)
+}
+```
+
+## 错误处理
+
+```rust
+#[derive(Debug)]
+pub enum PagingError {
+    PageFault,        // 页面不存在
+    AlreadyMapped,    // 页面已映射
+    InvalidFlags,     // 标志位无效
+    FrameAllocFailed, // 物理帧分配失败
+}
+
+pub type PagingResult<T> = Result<T, PagingError>;
+```
+
+## 常见问题
+
+### Q1: 为什么需要刷新 TLB？
+
+**A**: TLB 缓存虚拟地址到物理地址的翻译结果。修改页表后，必须刷新 TLB 以保证硬件使用最新映射。
+
+### Q2: 什么时候使用 tlb_flush_all？
+
+**A**:
+- 切换页表（如进程切换）
+- 批量修改映射时
+- 单个 `tlb_flush` 适用于修改少量页面
+
+### Q3: translate 和 walk 的区别？
+
+**A**:
+- `translate(vaddr)`：快速翻译，仅返回物理地址
+- `walk(vpn)`：返回完整映射信息（PPN、大小、标志），用于调试
+
+### Q4: 为什么 VADDR_START 是 0xffff_ffc0_0000_0000？
+
+**A**: 这是 SV39 高半核的起始地址：
+- Bit 38 = 1，符号扩展后 bits [63:39] 全为 1
+- 低 38 位全为 0
+- 结果：`0xffff_ffc0_0000_0000`
+
+## 性能考量
+
+### TLB 性能
+
+- TLB 命中率通常 > 95%
+- TLB Miss 惩罚：~100 CPU 周期
+- 合理规划映射可提高 TLB 命中率
+
+### 大页支持
+
+当前实现中大页已暂时禁用。未来启用时：
+- 2MB 大页：减少 TLB 压力
+- 1GB 巨页：适用于大块连续内存
+
+## 相关文档
+
+- [地址抽象层](address.md) - Vpn/Ppn 类型
+- [物理帧分配器](frame_allocator.md) - 页表帧的分配
+- [整体架构](architecture.md) - MM 子系统分层设计
+- [API 参考](api_reference.md) - 完整 API 列表
+
+## 参考实现
+
+- **架构无关层**：`os/src/mm/page_table/`
+- **RISC-V 实现**：`os/src/arch/riscv/mm/page_table.rs`
+- **RISC-V 规范**：SV39 Paging Scheme


### PR DESCRIPTION
## 📝 Documentation / 文档更新

### 📄 描述 (Description)

为 MM 子系统创建完整的技术文档，包含架构设计、核心模块说明和 API 参考。

#### 哪个文件或区域被修改了？

新增文档（8 个文件）：
- document/mm/README.md - 主索引、内存布局图、文档导航
- document/mm/architecture.md - MM 子系统整体架构和分层设计
- document/mm/address.md - 地址抽象层（Paddr/Vaddr/Ppn/Vpn）
- document/mm/frame_allocator.md - 物理帧分配器（水位线+回收栈、RAII）
- document/mm/global_allocator.md - 全局堆分配器（talc 实现）
- document/mm/page_table.md - 页表抽象层（PageTableInner trait、SV39）
- document/mm/memory_space.md - 地址空间管理（MemorySpace、MappingArea）
- document/mm/api_reference.md - 完整 API 索引

覆盖的源码模块：
- os/src/mm/ - 架构无关的内存管理层
- os/src/arch/riscv/mm/ - RISC-V SV39 实现
- os/src/config.rs - 内存布局常量
- os/src/linker.ld - 内核链接脚本

#### 修改了哪些关键信息？

1. 内存布局说明 (README.md)
- 完整的高半核（Higher Half Kernel）虚拟地址空间布局
- 低半核用户空间布局
- 物理地址到虚拟地址的映射关系（基于 VADDR_START = 0xFFFF_FFC0_0000_0000）
- 内核从 VIRTUAL_BASE (0xFFFF_FFC0_8020_0000) 向上增长的布局
2. 架构抽象机制 (architecture.md)
- MM 子系统的三层架构设计
- 架构无关层与架构特定层的分离
- trait 系统的使用（PageTableInner、PageTableEntry）
- 初始化流程和模块依赖关系
3. 核心数据结构和 API (各模块文档)
- 地址类型的 repr(transparent) 设计
- FrameTracker 的 RAII 自动回收机制
- PageTableInner trait 的完整接口
- UniversalPTEFlag 架构无关标志位
- MemorySpace 的映射策略（Direct vs Framed）
4. 实用示例和常见陷阱
- 物理帧分配的生命周期管理
- 页表映射的 TLB 刷新时机
- 地址空间创建和系统调用实现
- fork 时的深拷贝处理

#### 为什么需要这次更新？

当前问题：
- MM 子系统缺少系统性文档，新贡献者理解代码困难
- 架构设计思想未明确记录
- 关键 API 的使用方法和注意事项不清晰
- 高半核内存布局未在文档中说明

文档价值：
- 降低新贡献者的学习成本
- 明确架构抽象层次，便于添加新架构支持（如 LoongArch）
- 提供实用的代码示例和使用场景
- 作为项目技术知识库的一部分

### 💡 更改类型 (Change Type)

请选择您正在进行的更改类型：

- [ ] 修复现有文档中的错误或错别字。
- [X] 添加了新的文档页面或指南。
- [ ] 更新了现有功能的使用说明。
- [ ] 改进了代码注释或 JSDoc。

### 📊 文档结构

document/mm/
├── README.md              # 主索引（内存布局、快速开始、文档导航）
├── architecture.md        # 整体架构（分层设计、初始化流程）
├── address.md            # 地址抽象层
├── frame_allocator.md    # 物理帧分配器
├── global_allocator.md   # 全局堆分配器
├── page_table.md         # 页表抽象层
├── memory_space.md       # 地址空间管理
└── api_reference.md      # API 快速索引

### 🔗关联
Close Issue #57 
