### PR TITLE
fix: 修复文档注释

### DIFF
--- a/os/src/mm/address/address.rs
+++ b/os/src/mm/address/address.rs
@@ -217,7 +217,7 @@ where
         Self { start, end }
     }
 
-    /// create an address range from a Range<T>
+    /// create an address range from a `Range<T>`
     pub fn from_range(range: Range<T>) -> Self {
         Self {
             start: range.start,

--- a/os/src/mm/address/mod.rs
+++ b/os/src/mm/address/mod.rs
@@ -8,18 +8,18 @@
 //!
 //! # Address Types
 //!
-//! - [`Address`]: Trait for representing memory addresses (physical or virtual)
+//! - `Address`: Trait for representing memory addresses (physical or virtual)
 //! - [`Paddr`]: Physical address type
 //! - [`Vaddr`]: Virtual address type
 //! - [`ConvertablePaddr`]: Trait for converting physical addresses to virtual addresses
-//! - [`ConvertableVaddr`]: Trait for converting virtual addresses to physical addresses
+//! - `ConvertableVaddr`: Trait for converting virtual addresses to physical addresses
 //!
 //! # Address Ranges
 //!
-//! - [`AddressRange`]: Generic range of addresses
-//! - [`PaddrRange`]: Type alias for physical address range
-//! - [`VaddrRange`]: Type alias for virtual address range
-//! - [`AddressRangeIterator`]: Iterator for address ranges
+//! - `AddressRange`: Generic range of addresses
+//! - `PaddrRange`: Type alias for physical address range
+//! - `VaddrRange`: Type alias for virtual address range
+//! - `AddressRangeIterator`: Iterator for address ranges
 //!
 //! # Page Numbers
 //!
@@ -29,18 +29,18 @@
 //!
 //! # Page Number Ranges
 //!
-//! - [`PageNumRange`]: Generic range of page numbers
+//! - `PageNumRange`: Generic range of page numbers
 //! - [`PpnRange`]: Type alias for physical page number range
 //! - [`VpnRange`]: Type alias for virtual page number range
-//! - [`PageNumRangeIterator`]: Iterator for page number ranges
+//! - `PageNumRangeIterator`: Iterator for page number ranges
 //!
 //! # Operations
 //!
 //! The module provides three key trait categories:
 //!
 //! - [`UsizeConvert`]: Convert between types and usize
-//! - [`CalcOps`]: Arithmetic and bitwise operations
-//! - [`AlignOps`]: Address alignment operations
+//! - `CalcOps`: Arithmetic and bitwise operations
+//! - `AlignOps`: Address alignment operations
 
 mod address;
 mod operations;

--- a/os/src/mm/address/page_num.rs
+++ b/os/src/mm/address/page_num.rs
@@ -110,7 +110,7 @@ where
         Self { start, end }
     }
 
-    /// create a page number range from a Range<T>
+    /// create a page number range from a `Range<T>`
     pub fn from_range(range: Range<T>) -> Self {
         Self {
             start: range.start,

--- a/os/src/mm/frame_allocator/mod.rs
+++ b/os/src/mm/frame_allocator/mod.rs
@@ -11,9 +11,9 @@
 //! - [`FrameRangeTracker`]: RAII wrapper for ranges of allocated frames
 //! - [`init_frame_allocator`]: Initialize the global frame allocator
 //! - [`alloc_frame`]: Allocate a single frame
-//! - [`alloc_frames`]: Allocate multiple (non-contiguous) frames
-//! - [`alloc_contig_frames`]: Allocate multiple contiguous frames
-//! - [`alloc_contig_frames_aligned`]: Allocate multiple contiguous frames with alignment
+//! - `alloc_frames`: Allocate multiple (non-contiguous) frames
+//! - `alloc_contig_frames`: Allocate multiple contiguous frames
+//! - `alloc_contig_frames_aligned`: Allocate multiple contiguous frames with alignment
 
 mod frame_allocator;
 mod physmem;

--- a/os/src/mm/mod.rs
+++ b/os/src/mm/mod.rs
@@ -8,7 +8,7 @@
 //!
 //! - [`address`]: Address and page number abstractions
 //! - [`frame_allocator`]: Physical frame allocation
-//! - [`global_allocator`]: Global heap allocator
+//! - [`mod@global_allocator`]: Global heap allocator
 //! - [`memory_space`]: Memory space management
 //! - [`page_table`]: Page table abstractions and implementations(arch-independent)
 


### PR DESCRIPTION
## 🐞 Bug Fix / 错误修复

### 🐛 描述 (Description)

修复 cargo doc 生成失败的问题：文档注释中使用了 rustdoc 链接语法引用未导出的类型（如 Address、ConvertableVaddr、alloc_frames 等），导致 13 个 "unresolved link" 错误；同时修复了 Range<T> HTML 标签未转义警告和 global_allocator 模糊链接错误