### PR TITLE
fix: 修复文档部署工作流中 api 目录冲突问题

### DIFF
--- a/.github/workflows/docs-deployment.yml
+++ b/.github/workflows/docs-deployment.yml
@@ -55,6 +55,8 @@ jobs:
           mkdir -p site
           # 复制 mdBook 输出
           cp -r book/* site/
+          # 删除 mdBook 生成的 api 目录（如果存在），避免与 cargo doc 输出冲突
+          rm -rf site/api
           # 复制 cargo doc 输出到 api 子目录
           mkdir -p site/api
           cp -r os/target/riscv64gc-unknown-none-elf/doc/* site/api/


### PR DESCRIPTION
## 🐞 Bug Fix / 错误修复

  ### 🐛 描述 (Description)

  本 PR 修复了文档部署工作流中 api 目录冲突导致的构建失败问题。

  **问题背景：**
  在文档部署工作流的"合并文档到统一目录"步骤中，会依次执行：
  1. 复制 mdBook 生成的文档到 `site/` 目录
  2. 复制 cargo doc 生成的 API 文档到 `site/api/` 目录

  由于 `document/SUMMARY.md` 中包含 `[API 文档](api/os)` 链接，mdBook 会生成 `book/api/os` 文件（或 `os.html`）。当工作流尝试将 cargo doc 生成的 `os`
  目录（包含完整的 API 文档）复制到 `site/api/os` 时，会因为同名文件已存在而报错：
  cp: cannot overwrite non-directory 'site/api/os' with directory 'os/target/riscv64gc-unknown-none-elf/doc/os'

  **解决方案：**
  在复制 cargo doc 输出前，先执行 `rm -rf site/api` 删除 mdBook 生成的 api 目录，确保不会发生冲突。

  **改动文件：**
  - `.github/workflows/docs-deployment.yml:58-59` - 添加删除 `site/api` 目录的命令

  ### 🚨 重现步骤 (Steps to Reproduce)

  **修复前的问题重现：**

  1. 推送代码到 main 分支，触发文档部署工作流
  2. 工作流执行到"合并文档到统一目录"步骤
  3. 预期结果：成功合并文档
  4. 实际结果（Bug 现象）：工作流失败，报错 `cp: cannot overwrite non-directory 'site/api/os' with directory`

  或本地复现：

  1. 执行 `mdbook build`（生成 `book/api/os` 文件）
  2. 执行 `cd os && cargo doc --no-deps --target riscv64gc-unknown-none-elf`
  3. 执行合并命令（工作流第 55-60 行）
  4. 预期结果：文档合并成功
  5. 实际结果（Bug 现象）：cp 命令报错退出

  ### 🔗 关联 Issue

  Fixes #84 