### PR TITLE
fix: 修复了文档部署工作流中的API文档链接错误问题

### DIFF
--- a/document/SUMMARY.md
+++ b/document/SUMMARY.md
@@ -57,4 +57,4 @@
 
 ---
 
-[API 文档](api/os)
+[API 文档](api/os/)


### PR DESCRIPTION
## 🐞 Bug Fix / 错误修复

### 🐛 描述 (Description)

  侧边栏的"API 文档"链接跳转到 `api/os.html`（文件），而实际应该跳转到 `api/os/`（目录）以显示 cargo doc 生成的 API 文档。

### 🔍 根本原因

  `document/SUMMARY.md` 中的 API 文档链接写作 `[API 文档](api/os)`，缺少末尾斜杠。这导致：

  1. **mdBook 行为**：将 `api/os` 识别为文件而非目录，生成 `book/api/os.html` 文件
  2. **工作流冲突**：当尝试复制 cargo doc 生成的 `os` 目录到 `site/api/os` 时，发现已存在同名文件，无法覆盖
  3. **链接错误**：用户点击链接时跳转到 `.html` 文件而非 API 文档目录

### 🔗 关联 Issue

Fixes #86 
