### PR TITLE
fix: 增加 boot_stack_lower_bound 的空间大小至 48KB以解决网络设备初始化时的栈溢出问题

### DIFF
--- a/os/src/arch/riscv/boot/entry.S
+++ b/os/src/arch/riscv/boot/entry.S
@@ -63,6 +63,6 @@ boot_pagetable:
     .section .bss.stack
     .globl boot_stack_lower_bound
 boot_stack_lower_bound:
-    .space 4096 * 16
+    .space 4096 * 48
     .globl boot_stack_top
 boot_stack_top:

--- a/os/src/device/net/virtio_net.rs
+++ b/os/src/device/net/virtio_net.rs
@@ -5,7 +5,7 @@ use crate::{
         Driver,
         net::{add_network_device, interface::NetworkInterface, net_device::VirtioNetDevice},
     },
-    earlyprintln, println,
+    earlyprintln,
     sync::SpinLock,
 };
 use alloc::{format, sync::Arc};
@@ -18,43 +18,43 @@ lazy_static! {
 pub fn init(transport: MmioTransport<'static>) {
     earlyprintln!("[Device] Initializing network driver (virtio-net)");
 
-    // // 获取设备ID
-    // let device_id = {
-    //     let mut count = NET_DEVICE_COUNT.lock();
-    //     let id = *count;
-    //     println!("[Device] Find VirtioNetDevice with ID: {}", id);
-    //     *count += 1;
-    //     id
-    // };
+    // 获取设备ID
+    let device_id = {
+        let mut count = NET_DEVICE_COUNT.lock();
+        let id = *count;
+        earlyprintln!("[Device] Find VirtioNetDevice with ID: {}", id);
+        *count += 1;
+        id
+    };
 
-    // // 创建VirtioNetDevice
-    // match VirtioNetDevice::new(transport, device_id) {
-    //     Ok(virtio_device) => {
-    //         println!("[Device] VirtioNetDevice created with ID: {}", device_id);
+    // 创建VirtioNetDevice
+    match VirtioNetDevice::new(transport, device_id) {
+        Ok(virtio_device) => {
+            earlyprintln!("[Device] VirtioNetDevice created with ID: {}", device_id);
 
-    //         // 创建网络接口
-    //         let interface_name = format!("eth{}", device_id);
-    //         let network_interface =
-    //             Arc::new(NetworkInterface::new(interface_name, virtio_device.clone()));
+            // 创建网络接口
+            let interface_name = format!("eth{}", device_id);
+            let network_interface =
+                Arc::new(NetworkInterface::new(interface_name, virtio_device.clone()));
 
-    //         // 将设备添加到全局设备列表
-    //         add_network_device(virtio_device.clone());
+            // 将设备添加到全局设备列表
+            add_network_device(virtio_device.clone());
 
-    //         // 将接口添加到全局接口管理器
-    //         crate::device::net::interface::NETWORK_INTERFACE_MANAGER
-    //             .lock()
-    //             .add_interface(network_interface.clone());
+            // 将接口添加到全局接口管理器
+            crate::device::net::interface::NETWORK_INTERFACE_MANAGER
+                .lock()
+                .add_interface(network_interface.clone());
 
-    //         // 注册设备驱动
-    //         crate::device::register_driver(network_interface.clone() as Arc<dyn Driver>);
+            // 注册设备驱动
+            crate::device::register_driver(network_interface.clone() as Arc<dyn Driver>);
 
-    //         println!(
-    //             "[Device] Network interface {} initialized successfully",
-    //             network_interface.name()
-    //         );
-    //     }
-    //     Err(e) => {
-    //         println!("[Device] Failed to initialize VirtioNetDevice: {:?}", e);
-    //     }
-    // }
+            earlyprintln!(
+                "[Device] Network interface {} initialized successfully",
+                network_interface.name()
+            );
+        }
+        Err(e) => {
+            earlyprintln!("[Device] Failed to initialize VirtioNetDevice: {:?}", e);
+        }
+    }
 }


### PR DESCRIPTION
## ✨ Fix / 解决网络设备初始化时的栈溢出问题

### 🚀 描述 (Description)

本次拉取请求主要实现了对 **Virtio 网络设备的初始化日志增强**和 **RISC-V 启动堆栈空间的扩展**。

**核心改进点：**

1.  **启动日志增强**：统一使用 **`earlyprintln!`** 宏进行 Virtio 网络设备的初始化日志输出，确保在内核启动的早期阶段即可获取诊断信息，极大地便利了调试。
2.  **启动堆栈扩展**：显著**增加了 RISC-V 架构的启动堆栈大小**，为更复杂的初始化和设备驱动加载提供了更安全的缓冲空间，提高了系统启动的稳定性。

---

### 📦 核心改动 (Core Changes)

#### 1. 网络设备初始化与日志改进 📝

* **统一日志输出**：
    * 更新了 **`virtio_net.rs`** 中的 `init` 函数，将所有初始化日志输出从旧的 `println!` 或注释掉的代码，统一替换为使用 **`earlyprintln!`**。
    * 这确保了网络设备的初始化状态和错误在**早期启动阶段**（控制台驱动完全设置之前）就能被捕获和显示。
* **代码清理**：
    * 移除了 `virtio_net.rs` 中不再使用的 `println` 导入。

#### 2. RISC-V 启动堆栈配置 💾

* **堆栈空间增加**：
    * 在 **`entry.S`** 中，将**启动堆栈 ($\text{Boot Stack}$) **的大小从 $4096 \times 16$ 字节增加到 **$4096 \times 48$ 字节**。 
    * 此调整为复杂的启动初始化流程提供了更充足的堆栈空间，降低了堆栈溢出的风险。

---

### 🔗 关联 Issue

Resolves #133 
