### PR TITLE
fix：修正 Auxv 对齐与 execve 参数传递，解决 BusyBox 启动崩溃问题

### DIFF
--- a/os/src/arch/riscv/kernel/task.rs
+++ b/os/src/arch/riscv/kernel/task.rs
@@ -74,39 +74,40 @@ pub fn setup_stack_layout(
     sp &= !(size_of::<usize>() * 2 - 1); // Align to 16 bytes
 
     // 4. AT_EXECFN (use argv[0] if available)
-    let execfn = if !arg_ptrs.is_empty() {
-        arg_ptrs[0]
-    } else {
-        0
-    };
+    let execfn = if !arg_ptrs.is_empty() { arg_ptrs[0] } else { 0 };
 
     let auxv = [
-        (3, phdr_addr),   // AT_PHDR
-        (4, phent),       // AT_PHENT
-        (5, phnum),       // AT_PHNUM
-        (6, 4096),        // AT_PAGESZ
-        (7, 0),           // AT_BASE
-        (8, 0),           // AT_FLAGS
-        (9, entry_point), // AT_ENTRY
-        (11, 0),          // AT_UID
-        (12, 0),          // AT_EUID
-        (13, 0),          // AT_GID
-        (14, 0),          // AT_EGID
+        (3, phdr_addr),     // AT_PHDR
+        (4, phent),         // AT_PHENT
+        (5, phnum),         // AT_PHNUM
+        (6, 4096),          // AT_PAGESZ
+        (7, 0),             // AT_BASE
+        (8, 0),             // AT_FLAGS
+        (9, entry_point),   // AT_ENTRY
+        (11, 0),            // AT_UID
+        (12, 0),            // AT_EUID
+        (13, 0),            // AT_GID
+        (14, 0),            // AT_EGID
         (15, platform_ptr), // AT_PLATFORM
-        (16, 0),          // AT_HWCAP
-        (17, 100),        // AT_CLKTCK
-        (23, 0),          // AT_SECURE
-        (25, random_ptr), // AT_RANDOM
-        (31, execfn),     // AT_EXECFN
-        (0, 0),           // AT_NULL
+        (16, 0),            // AT_HWCAP
+        (17, 100),          // AT_CLKTCK
+        (23, 0),            // AT_SECURE
+        (25, random_ptr),   // AT_RANDOM
+        (31, execfn),       // AT_EXECFN
+        (0, 0),             // AT_NULL
     ];
 
     // Debug print auxv
     for (i, (k, v)) in auxv.iter().enumerate() {
         crate::pr_debug!("auxv[{}]: type={}, val={:#x}", i, k, v);
     }
-    crate::pr_debug!("setup_stack_layout: sp={:#x}, random_ptr={:#x}, phdr_addr={:#x}, entry={:#x}", sp, random_ptr, phdr_addr, entry_point);
-
+    crate::pr_debug!(
+        "setup_stack_layout: sp={:#x}, random_ptr={:#x}, phdr_addr={:#x}, entry={:#x}",
+        sp,
+        random_ptr,
+        phdr_addr,
+        entry_point
+    );
 
     // Calculate total size of the pointer block to ensure final sp is 16-byte aligned
     // Block includes: auxv[], padding, envp NULL, envp[], argv NULL, argv[], argc


### PR DESCRIPTION
## 🐞 Bug Fix / 错误修复

### 🐛 描述 (Description)

修复了 BusyBox `init` 进程在启动时发生 `Load Page Fault` (0x65eec) 的严重问题。
该问题由两个主要原因引起：
1.  **Auxv 对齐问题**：`busybox` 解析辅助向量时存在 8 字节错位。
2.  **执行环境不纯净**：`execve` 未彻底清理寄存器和设置参数。

本 PR 包含以下关键修复：
1.  **Fix Misalignment**: 在 `setup_stack_layout` 中，于 `envp` 和 `auxv` 之间插入一个额外的 NULL 指针，修正了 `busybox` 的解析错位。
2.  **Fix Argument Passing**: 在 `set_exec_trap_frame` 中，确保在清空所有寄存器后，正确设置 `a0` (argc), `a1` (argv), `a2` (envp)。
3.  **Close CLOEXEC FDs**: 在 `execve` 中实现了 `FD_CLOEXEC` 逻辑，防止文件描述符泄漏到新进程。

### 🚨 重现步骤 (Steps to Reproduce)

1. 编译并运行内核，加载 `busybox` 作为 init。
2. 观察启动日志。
3. **预期结果**：`busybox` 成功启动，进入 shell 或执行 init 脚本。
4. **实际结果（Bug 现象）**：`busybox` 在 `0x65eec` 处崩溃，报 `Load Page Fault`。

### 🔗 关联 Issue

Closes #164 
