### PR TITLE
fix: 优化 notify_parent 函数中的日志输出，避免重复锁定任务

### DIFF
--- a/os/src/kernel/task/mod.rs
+++ b/os/src/kernel/task/mod.rs
@@ -109,10 +109,11 @@ pub fn notify_parent(task: SharedTask) {
         t.send_signal(p, NUM_SIGCHLD);
     } else {
         // Parent not found (e.g. init process exiting), ignore
+        let pid = task.lock().pid;
         crate::pr_warn!(
             "notify_parent: parent task {} not found for child {}",
             ppid,
-            task.lock().pid
+            pid
         );
     }
 }


### PR DESCRIPTION
修复notify_parint中重复获取任务造成的死锁
