### PR TITLE
fix: 添加 try_lock 方法以避免死锁并优化 log 系统的死锁问题

### DIFF
--- a/os/src/sync/spin_lock.rs
+++ b/os/src/sync/spin_lock.rs
@@ -40,6 +40,14 @@ impl<T> SpinLock<T> {
         }
     }
 
+    /// 尝试获取自旋锁，如果成功则返回 RAII 保护器，否则返回 None。
+    pub fn try_lock(&self) -> Option<SpinLockGuard<'_, T>> {
+        self.raw_lock.try_lock().map(|_raw_guard| SpinLockGuard {
+            _raw_guard,
+            data: unsafe { &mut *self.data.get() },
+        })
+    }
+
     /// 检查锁是否被占用 (仅用于调试/测试)
     /// 返回值：锁是否被占用
     #[cfg(test)]


### PR DESCRIPTION
## 🐞 Bug Fix / 错误修复

### 🐛 描述 (Description)

为 spinlock 添加 try_lock 方法以避免死锁

然后将log子系统的 collect context 中获取taskid的方法改为try_lock

### 🔗 关联 Issue

Closes #168 
