### PR TITLE
refactor: 清理跨模块架构常量访问

### DIFF
--- a/os/src/arch/arch_impl.rs
+++ b/os/src/arch/arch_impl.rs
@@ -22,6 +22,7 @@ macro_rules! impl_arch {
             type KernelAddressSpace = $kernel_space;
 
             const PAGE_OFFSET: usize = mm::VADDR_START;
+            const USER_TOP: usize = constant::USER_TOP;
 
             fn kern_address_space() -> &'static SpinLock<Self::KernelAddressSpace> {
                 &KERN_ADDR_SPACE
@@ -85,7 +86,7 @@ macro_rules! impl_arch {
                 max_len: usize,
             ) -> Result<usize, ()> {
                 let src = src.as_usize();
-                if src < constant::USER_BASE || src > constant::USER_TOP {
+                if !(constant::USER_BASE..=<$arch as VirtualMemory>::USER_TOP).contains(&src) {
                     return Err(());
                 }
                 if max_len != 0 && dst.is_null() {
@@ -143,12 +144,12 @@ macro_rules! impl_arch {
             if len == 0 {
                 return Ok(());
             }
-            if start < constant::USER_BASE || start > constant::USER_TOP {
+            if !(constant::USER_BASE..=<$arch as VirtualMemory>::USER_TOP).contains(&start) {
                 return Err(());
             }
             let end = start.checked_add(len).ok_or(())?;
             let last = end.checked_sub(1).ok_or(())?;
-            if last > constant::USER_TOP {
+            if last > <$arch as VirtualMemory>::USER_TOP {
                 return Err(());
             }
 

--- a/os/src/arch/mock/arch.rs
+++ b/os/src/arch/mock/arch.rs
@@ -189,6 +189,7 @@ impl VirtualMemory for MockArch {
     type ProcessAddressSpace = MockAddressSpace;
     type KernelAddressSpace = MockAddressSpace;
     const PAGE_OFFSET: usize = 0xffff_ffc0_0000_0000;
+    const USER_TOP: usize = super::constant::USER_TOP;
 
     fn kern_address_space() -> &'static SpinLock<Self::KernelAddressSpace> {
         static KERN_SPACE: SpinLock<MockAddressSpace> = SpinLock::new(MockAddressSpace::new());

--- a/os/src/arch/mod.rs
+++ b/os/src/arch/mod.rs
@@ -51,6 +51,8 @@ mod mock;
 #[cfg(not(any(target_arch = "riscv64", target_arch = "loongarch64")))]
 pub use mock::*;
 
+pub use constant::SUPERVISOR_EXTERNAL;
+
 // ---- ArchImpl 类型别名 ----
 // 内核其余部分通过 ArchImpl 访问架构特定功能，无需关心具体架构。
 #[cfg(target_arch = "riscv64")]

--- a/os/src/arch/virtual_memory.rs
+++ b/os/src/arch/virtual_memory.rs
@@ -166,6 +166,9 @@ pub trait VirtualMemory: CpuOps + Sized {
     /// 对于直接映射，`paddr + PAGE_OFFSET = vaddr`。
     const PAGE_OFFSET: usize;
 
+    /// 用户地址空间最高可访问地址
+    const USER_TOP: usize;
+
     /// 获取全局内核地址空间
     fn kern_address_space() -> &'static SpinLock<Self::KernelAddressSpace>;
 }

--- a/os/src/config.rs
+++ b/os/src/config.rs
@@ -12,6 +12,9 @@ pub const USER_STACK_SIZE: usize = 4 * 1024 * 1024; // 4MB
 
 pub const MAX_ARGV: usize = 256;
 
+use crate::arch::{ArchImpl, virtual_memory::VirtualMemory};
+use crate::util::address::align_down;
+
 // User space memory layout constants
 // Memory layout (from high to low address):
 // [USER_STACK]          <--
@@ -20,13 +23,15 @@ pub const MAX_ARGV: usize = 256;
 // [USER_DATA]
 // [USER_TEXT]
 
-pub const USER_STACK_TOP: usize = SV39_BOT_HALF_TOP - PAGE_SIZE; // leave another guard page
+/// Leave one guard page below the top of the user address space.
+pub const USER_STACK_TOP: usize = <ArchImpl as VirtualMemory>::USER_TOP - PAGE_SIZE;
 
 /// Userspace rt_sigreturn trampoline address (one RX page).
 ///
 /// Must not overlap with the user stack mapping. With the current (non page-aligned) `USER_STACK_TOP`,
-/// the stack mapping ends at `align_down(SV39_BOT_HALF_TOP, PAGE_SIZE)`, so we place the trampoline there.
-pub const USER_SIGRETURN_TRAMPOLINE: usize = SV39_BOT_HALF_TOP & !(PAGE_SIZE - 1);
+/// the stack mapping ends at `align_down(USER_TOP, PAGE_SIZE)`, so we place the trampoline there.
+pub const USER_SIGRETURN_TRAMPOLINE: usize =
+    align_down(<ArchImpl as VirtualMemory>::USER_TOP, PAGE_SIZE);
 
 /// Maximum heap size (prevent OOM)
 pub const MAX_USER_HEAP_SIZE: usize = 64 * 1024 * 1024; // 64MB
@@ -40,5 +45,3 @@ pub const EXT4_BLOCK_SIZE: usize = 4096;
 pub const VIRTIO_BLK_SECTOR_SIZE: usize = 512;
 /// 文件系统镜像大小 (与 qemu-run.sh 中的 fs.img 大小一致)
 pub const FS_IMAGE_SIZE: usize = 1024 * 1024 * 1024; // 1 GB
-
-use crate::arch::constant::SV39_BOT_HALF_TOP;

--- a/os/src/device/irq/plic.rs
+++ b/os/src/device/irq/plic.rs
@@ -3,7 +3,7 @@
 //! PLIC 提供对外设中断的集中管理，支持优先级和中断分发功能。
 
 use super::{super::DRIVERS, IrqManager};
-use crate::arch::constant::SUPERVISOR_EXTERNAL;
+use crate::arch::SUPERVISOR_EXTERNAL;
 use crate::device::device_tree::{DEVICE_TREE_INTC, DEVICE_TREE_REGISTRY};
 use crate::device::irq::IntcDriver;
 use crate::device::{DeviceType, Driver, IRQ_MANAGER};

--- a/os/src/util/address.rs
+++ b/os/src/util/address.rs
@@ -2,7 +2,7 @@
 
 /// 这是一个安全且常见的 align_down 实现
 /// T 必须是整数类型
-pub fn align_down(addr: usize, align: usize) -> usize {
+pub const fn align_down(addr: usize, align: usize) -> usize {
     // 对齐值必须是 2 的幂，否则行为可能不正确
     debug_assert!(align.is_power_of_two());
 

--- a/os/src/util/user_buffer.rs
+++ b/os/src/util/user_buffer.rs
@@ -6,8 +6,7 @@
 use alloc::vec::Vec;
 use core::mem::MaybeUninit;
 
-use crate::arch::constant::USER_TOP;
-use crate::arch::{Arch, address::UA};
+use crate::arch::{Arch, ArchImpl, address::UA, virtual_memory::VirtualMemory};
 
 /// 向用户空间写入数据
 /// # 参数
@@ -104,7 +103,7 @@ impl UserBuffer {
         let Some(end) = start.checked_add(self.len) else {
             return false;
         };
-        end <= USER_TOP
+        end <= <ArchImpl as VirtualMemory>::USER_TOP
     }
 
     /// 返回用户缓冲区长度
@@ -147,13 +146,13 @@ pub fn validate_user_ptr<T>(ptr: *const T) -> bool {
 
     // 检查起始地址是否在用户空间范围内
     // USER_BASE 为 0，所以只需检查上界
-    if addr > USER_TOP {
+    if addr > <ArchImpl as VirtualMemory>::USER_TOP {
         return false;
     }
 
     // 检查是否会溢出用户空间
     if let Some(end_addr) = addr.checked_add(size) {
-        if end_addr > USER_TOP + 1 {
+        if end_addr > <ArchImpl as VirtualMemory>::USER_TOP + 1 {
             return false;
         }
     } else {


### PR DESCRIPTION
## 变更内容

本 PR 处理 #250，主要收敛通用代码对架构常量的跨模块直接访问，减少 `arch::constant` 泄漏到 common code。

- 在 `VirtualMemory` 中新增架构无关的 `USER_TOP` 关联常量
- `config.rs` 通过 `VirtualMemory::USER_TOP` 计算用户栈布局，并在 common config 中明确保留 guard page
- `user_buffer.rs` 和用户拷贝校验逻辑改为通过 `VirtualMemory::USER_TOP` 做用户地址范围检查
- `PLIC` 保留 `SUPERVISOR_EXTERNAL` 使用，但改为通过 `crate::arch::SUPERVISOR_EXTERNAL` 短路径访问
- 将 `align_down` 改为 `const fn`，用于编译期计算 sigreturn trampoline 地址

## 验证情况

- `cargo check --target riscv64gc-unknown-none-elf`
- `cargo fmt --all -- --check`
- `cargo clippy --target riscv64gc-unknown-none-elf`
- `make run TEST=1`

`make run TEST=1` 结果：`Total: 510, Passed: 510, Failed: 0`

Closes #250