### PR TITLE
chore: 回退 Rust 工具链至 nightly-2025-01-18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  RUST_TOOLCHAIN: nightly-2025-10-28
+  RUST_TOOLCHAIN: nightly-2025-01-18
   
   QEMU_VERSION: qemu-9.2.1
   QEMU_BUILD_PATH: ${{ github.workspace }}/qemu-build-cache

--- a/.github/workflows/docs-deployment.yml
+++ b/.github/workflows/docs-deployment.yml
@@ -30,7 +30,7 @@ jobs:
       - name: 安装 Rust 工具链
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: nightly-2025-10-28
+          toolchain: nightly-2025-01-18
           targets: riscv64gc-unknown-none-elf
           components: rust-src, rustfmt, clippy
 

--- a/.github/workflows/mirror-to-gitlab.yml
+++ b/.github/workflows/mirror-to-gitlab.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Rust toolchain (for cargo vendor)
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2025-10-28
+          toolchain: nightly-2025-01-18
 
       - name: Prepare mirror commit (vendor + README swap)
         env:

--- a/os/rust-toolchain.toml
+++ b/os/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2025-10-28"
+channel = "nightly-2025-01-18"

--- a/os/src/arch/loongarch/boot/entry.S
+++ b/os/src/arch/loongarch/boot/entry.S
@@ -102,3 +102,6 @@ boot_stack_lower_bound:
     .space 4096 * 48                # 48 页 = 192KB 启动栈
     .globl boot_stack_top
 boot_stack_top:
+
+    # 切回 .text：与 riscv entry.S 同理，避免 global_asm! 拼接时后续代码块继承本 .bss 段。
+    .section .text

--- a/os/src/arch/riscv/boot/entry.S
+++ b/os/src/arch/riscv/boot/entry.S
@@ -127,3 +127,8 @@ secondary_stacks_bottom:
     .space 65536 * 8        # 8 核 × 64KB
     .globl secondary_stacks_top
 secondary_stacks_top:
+
+    # 切回 .text：本文件经 global_asm! 与 switch.S 等纯代码 .S 拼接为同一汇编单元，
+    # 若停在 .bss.secondary_stack（NOBITS）结束，后续代码块会继承该段，触发
+    # "SHT_NOBITS section cannot have instructions"（旧版 LLVM 严格报错）。
+    .section .text

--- a/os/src/kernel/syscall/fs/stat_ops.rs
+++ b/os/src/kernel/syscall/fs/stat_ops.rs
@@ -82,15 +82,12 @@ pub fn getdents64(fd: usize, dirp: *mut u8, count: usize) -> isize {
 
         // 写入 dirent 头部
         unsafe {
-            write_to_user(
-                dirp.add(written) as *mut LinuxDirent64,
-                LinuxDirent64 {
-                    d_ino: entry.inode_no as u64,
-                    d_off: current_off,
-                    d_reclen: dirent_len as u16,
-                    d_type: inode_type_to_d_type(entry.inode_type),
-                },
-            );
+            write_to_user(dirp.add(written) as *mut LinuxDirent64, LinuxDirent64 {
+                d_ino: entry.inode_no as u64,
+                d_off: current_off,
+                d_reclen: dirent_len as u16,
+                d_type: inode_type_to_d_type(entry.inode_type),
+            });
         }
 
         // 写入文件名到 d_name 字段（从 LinuxDirent64 offset 19 开始）

--- a/os/src/main.rs
+++ b/os/src/main.rs
@@ -7,6 +7,12 @@
 #![no_std]
 #![no_main]
 #![feature(custom_test_frameworks)]
+// 下列特性在 nightly-2025-10-28 已稳定，但本项目固定的 nightly-2025-01-18
+// (1.86-nightly，与评测机/参考项目 SanktaOS 对齐) 仍需显式开启。
+#![feature(let_chains)]
+#![feature(trait_upcasting)]
+#![feature(unsigned_is_multiple_of)]
+#![feature(ip_from)]
 #![test_runner(test_runner)]
 #![reexport_test_harness_main = "test_main"]
 

--- a/os/src/net/stack/mod.rs
+++ b/os/src/net/stack/mod.rs
@@ -370,13 +370,10 @@ impl NetworkStack {
                     sockets.remove(h);
                     return Err(NetworkError::AddressInUse);
                 }
-                ports.insert(
-                    port,
-                    UdpPortEntry {
-                        handle: h,
-                        sockets: alloc::vec::Vec::new(),
-                    },
-                );
+                ports.insert(port, UdpPortEntry {
+                    handle: h,
+                    sockets: alloc::vec::Vec::new(),
+                });
                 h
             }
         };


### PR DESCRIPTION
与评测机/参考项目 SanktaOS 对齐，将工具链从 nightly-2025-10-28 回退到 nightly-2025-01-18（1.86-nightly）。同步更新三个 workflow 的工具链版本。

该版本下若干特性尚未稳定，在 crate 根显式开启：let_chains、
trait_upcasting、unsigned_is_multiple_of、ip_from（业务代码不变）。 按旧版 rustfmt 归一化 stat_ops.rs / net/stack/mod.rs 的格式（结构体 字面量末参排版风格差异）。

验证：riscv/loongarch release 均编过；两架构预编译 std 在该版本均存在， 无需 build-std；fmt --check、clippy 均通过。

