### PR TITLE
 fix：提升 OS Contest 测试兼容性与文件系统/syscall 语义

### DIFF
--- a/docs/PR.md
+++ b/docs/PR.md
@@ -1,0 +1,220 @@
+# PR: 提升 OS Contest 测试兼容性与文件系统/syscall 语义
+
+## 背景
+
+本分支基于 `main`，围绕 OS Contest 官方测试镜像运行过程中的实际缺口，补齐了一批 Linux/POSIX 兼容语义。改动重点集中在 VFS、tmpfs/ext4、文件相关 syscall、部分网络 syscall，以及官方测试常见的 BusyBox/musl 行为。
+
+分支范围：
+
+- 当前分支：`ccy-dev01`
+- 对比基线：`main`
+- 提交数量：41
+- 主要影响目录：`os/src/vfs`、`os/src/fs`、`os/src/kernel/syscall`、`os/src/net`
+
+## 改动摘要
+
+本分支主要完成以下内容：
+
+- 支持 mknod 设备号编码/解码，并在 `stat` 结果中正确报告 `st_rdev`。
+- 补齐 tmpfs/ext4 对字符设备、块设备、FIFO、socket、普通文件等特殊节点的元数据支持。
+- 支持 named FIFO 打开语义、pipe size 查询和设置边界。
+- 新增最小 Unix domain socket 支持，覆盖基础本地 socket 使用场景。
+- 实现 `linkat`、tmpfs hard link、tmpfs rename，并修正跨设备 link、unlinkat removedir、rmdir link count 等语义。
+- 收紧 `openat`、`faccessat`、`fchmodat`、`fchownat`、`statx/fstatat`、`utimensat` 等 syscall 的 flag 和空路径处理。
+- 补齐 `O_NOFOLLOW`、`O_CLOEXEC`、`F_DUPFD` 下界、`getcwd` 小缓冲区返回 `ERANGE` 等 Linux 行为。
+- 保留路径最后组件的 `.`、`..` 和尾部 `/` 语义，按 syscall 分别返回更接近 Linux 的错误码。
+- 强化 `renameat2` 对空路径、特殊组件、尾部斜杠、目标类型校验的处理。
+- 支持 `fchmodat(..., "", mode, AT_EMPTY_PATH)`，修复 BusyBox `cp` preserve permissions 阶段返回 `EINVAL` 的问题。
+
+## 文件系统与 VFS
+
+### 设备号与特殊文件
+
+新增并使用 Linux 设备号编码/解码辅助函数，使 `mknodat` 创建的字符设备、块设备可以在 `stat` 中正确反映 `st_rdev`。
+
+涉及内容：
+
+- VFS 设备号 helper。
+- `mknodat` 解码用户态传入的 `dev_t`。
+- `stat`/`statx` 输出设备号。
+- tmpfs/ext4 保存特殊 inode 的 rdev 和 file type。
+
+### tmpfs 语义增强
+
+tmpfs 增强了特殊文件和目录项操作支持：
+
+- 精确解析 `mknod` 文件类型。
+- 支持 FIFO、字符设备、块设备、socket、普通文件的创建元数据。
+- 支持 hard link。
+- 支持 rename。
+- rmdir 时维护 link count。
+- chmod/chown/timestamps 等元数据路径保持可写。
+
+### ext4 语义增强
+
+ext4 侧补齐：
+
+- mknod 设备元数据。
+- rename 目标类型校验。
+- 目录覆盖非目录返回 `ENOTDIR`。
+- 非目录覆盖目录返回 `EISDIR`。
+
+### FIFO 与 pipe
+
+新增 named FIFO 打开支持，并改进 pipe 相关行为：
+
+- `open` FIFO 时返回 pipe file。
+- `F_GETPIPE_SZ` 返回实际 pipe size。
+- `F_SETPIPE_SZ` 对过小值进行最小值 clamp。
+
+## syscall 兼容性
+
+### 路径和空路径处理
+
+本分支修复了一批空路径行为：
+
+- `openat("")` 返回 `ENOENT`。
+- `readlinkat("")` 返回 `ENOENT`。
+- `faccessat("")` 返回 `ENOENT`。
+- `fchmodat/fchownat("")` 在无 `AT_EMPTY_PATH` 时返回 `ENOENT`。
+- `linkat` 源路径为空返回 `ENOENT`。
+- `renameat2` old/new path 为空返回 `ENOENT`。
+
+同时新增 `split_parent_preserving_basename()`，避免全局路径拆分提前吞掉最后组件 `.` 和 `..`。不同 syscall 对 final component 的语义不同，因此本分支没有粗暴修改全局 `split_path`，而是在 syscall 层分别处理。
+
+### open/fcntl
+
+改动包括：
+
+- `openat` 支持 `O_NOFOLLOW`。
+- `openat` 支持 `O_CLOEXEC`。
+- `openat` 拒绝 `O_CREAT` 创建目录目标的错误路径。
+- `fcntl(F_DUPFD)` 校验 lower bound。
+- pipe size 查询和设置更贴近 Linux 行为。
+
+### access/stat/chmod/chown/utimensat
+
+补齐内容：
+
+- `faccessat` flag 校验。
+- `fstatat/statx` flag 收紧。
+- `utimensat` 支持 `AT_EMPTY_PATH`。
+- `fchmodat/fchownat` flag 校验。
+- `fchmodat` 支持 `AT_EMPTY_PATH`，可通过 fd 对已打开文件 chmod。
+
+### mknod
+
+本分支修复：
+
+- `mknod(path, 0644)` 默认创建普通文件。
+- `mknod(S_IFDIR)` 返回 `EPERM`。
+- mknod 目标路径尾部斜杠按 Linux 错误码处理。
+- mknod 特殊文件类型和设备号在 tmpfs/ext4/stat 之间贯通。
+
+### link/unlink/rename
+
+新增/修复：
+
+- 实现 `linkat`。
+- tmpfs 支持 hard link。
+- 跨设备 hard link 返回 `EXDEV`。
+- `unlinkat(..., AT_REMOVEDIR)` 分流到 rmdir。
+- tmpfs 支持 rename。
+- `renameat2` 处理空路径、`.`/`..`、尾部斜杠、目标类型冲突。
+- ext4 rename 校验目录和非目录覆盖类型。
+
+### 尾部斜杠语义
+
+本分支对不同 syscall 分别实现尾部 `/` 行为：
+
+- `mkdirat("new/")`、`mkdirat("new//")` 可以成功。
+- `mkdirat("file/")`、`mkdirat("dir/")`、`mkdirat("/")` 返回 `EEXIST`。
+- `mknodat/symlinkat/linkat` 创建目标带尾部 `/` 时按 Linux 行为区分 `ENOENT`、`EEXIST`、`ENOTDIR`。
+- `renameat2` 源路径和目标路径尾部 `/` 分别校验是否必须为目录。
+
+## 网络
+
+新增最小 Unix domain socket 支持：
+
+- 新增 `os/src/net/unix_socket.rs`。
+- 扩展 socket syscall 路径，支持基础 Unix socket 创建、地址绑定、连接、收发和选项处理。
+- 补齐 socket 相关错误码和地址处理边界。
+
+这部分主要用于提升 BusyBox、libc、网络测试中对本地 socket 的基础兼容性，不等同于完整 Linux Unix socket 实现。
+
+## 主要提交列表
+
+```text
+f06cbeb vfs: add device number encoding helpers
+2dead4e syscall: decode mknodat device numbers
+f4fa8dd vfs: report device numbers in stat results
+57561b1 tmpfs: parse mknod file types exactly
+c82d7ef vfs: derive equality for file modes
+ac8c926 ext4: support mknod device metadata
+4e9aa7d vfs: support opening named fifos
+3c80b50 vfs: invalidate global dentry cache on removal
+393e80f net: add minimal unix domain sockets
+87343be syscall: implement linkat
+051de17 tmpfs: support hard links
+08f3a8d tmpfs: support rename
+57c42bc syscall: route unlinkat removedir to rmdir
+c1a9ed1 vfs: return exdev for cross-device links
+dccf4eb tmpfs: update link counts on rmdir
+3598bbd syscall: validate chmod chown at flags
+766a8b9 syscall: support utimensat empty path
+35384fa syscall: tighten stat at path flags
+facacc6 syscall: reject creat directory opens
+b4def61 fcntl: return actual pipe size
+8b1d325 pipe: clamp pipe size to minimum
+e260f7f syscall: validate faccessat inputs
+5965e7d syscall: preserve final path components
+15dc8b2 syscall: reject empty open paths
+084b58c syscall: support openat nofollow
+d881e35 fcntl: validate dupfd lower bound
+a262d98 syscall: honor openat cloexec
+1590f6a syscall: reject empty readlink paths
+0c95fc6 syscall: reject empty chmod chown paths
+690ae3a syscall: reject empty access paths
+acbf5d6 syscall: reject empty link sources
+dd22c98 syscall: default mknod type to regular file
+78c711c syscall: reject directory mknod with eperm
+42e1b96 syscall: report erange for small getcwd buffers
+0446089 syscall: reject empty rename paths
+35fd318 syscall: preserve special rename components
+e7e0e0c syscall: handle rename trailing slashes
+563ac69 ext4: validate rename target types
+035c64f syscall: allow mkdir trailing slashes
+cba140e syscall: handle creation trailing slashes
+0fda713 syscall: support fchmodat empty path
+```
+
+## 验证
+
+已使用官方测试机镜像进行格式和编译检查：
+
+```bash
+docker run --rm -v "$PWD":/workspace -w /workspace/os \
+  zhouzhouyi/os-contest:20260510 \
+  bash -lc 'cargo fmt --check && cargo check'
+```
+
+结果：通过。
+
+说明：
+
+- 检查输出中仍有大量既有 warning，本 PR 未处理这些存量 warning。
+- 本地宿主机上 `os/target` 和 `os/fs-riscv.img` 曾因测试镜像生成物归属为 root 导致直接 `cargo check` 权限失败，因此最终以指定 Docker 镜像内结果为准。
+
+## 风险与边界
+
+- Unix domain socket 是最小可用实现，不是完整 Linux 语义。
+- 多数路径语义修复按当前测试和 Linux 探测行为实现，仍可能存在少量 errno 优先级差异。
+- ext4 写路径仍可能受底层库写放大影响，性能问题不在本 PR 中完全解决。
+- 本 PR 强化了大量 syscall flag 校验，若用户程序依赖旧的宽松行为，可能暴露新的错误返回。
+
+## 后续建议
+
+- 继续按官方评分失分项补齐 glibc-rv、musl-la 启动和基础测试输出。
+- 针对 BusyBox 文件写入、复制、删除、文本处理类命令继续定位。
+- 对 iperf TCP、reverse TCP、parallel TCP 做网络路径专项排查。
+- 对大型 benchmark 和 LTP 分阶段补 syscall 覆盖，不建议一次性按全量 LTP 推进。

--- a/os/src/fs/ext4/inode.rs
+++ b/os/src/fs/ext4/inode.rs
@@ -13,6 +13,10 @@ use alloc::sync::{Arc, Weak};
 use alloc::vec::Vec;
 use ext4_rs::InodeFileType;
 
+use crate::vfs::dev::{
+    decode_ext4_new_dev, decode_ext4_old_dev, encode_ext4_new_dev, encode_ext4_old_dev,
+    major as dev_major, minor as dev_minor,
+};
 use crate::vfs::{Dentry, DirEntry, FileMode, FsError, Inode, InodeMetadata, InodeType};
 
 /// Ext4 Inode 包装
@@ -82,6 +86,54 @@ impl Ext4Inode {
             7 => InodeType::Symlink,     // EXT4_DE_SYMLINK
             _ => InodeType::File,
         }
+    }
+
+    fn mode_file_type(mode: FileMode) -> Result<InodeFileType, FsError> {
+        match mode & FileMode::S_IFMT {
+            FileMode::S_IFREG => Ok(InodeFileType::S_IFREG),
+            FileMode::S_IFCHR => Ok(InodeFileType::S_IFCHR),
+            FileMode::S_IFBLK => Ok(InodeFileType::S_IFBLK),
+            FileMode::S_IFIFO => Ok(InodeFileType::S_IFIFO),
+            FileMode::S_IFSOCK => Ok(InodeFileType::S_IFSOCK),
+            _ => Err(FsError::InvalidArgument),
+        }
+    }
+
+    fn regular_file_mode(mode: FileMode) -> u16 {
+        let permissions = mode.bits() & !FileMode::S_IFMT.bits();
+        (InodeFileType::S_IFREG.bits() as u32 | permissions) as u16
+    }
+
+    fn directory_mode(mode: FileMode) -> u16 {
+        let permissions = mode.bits() & !FileMode::S_IFMT.bits();
+        (InodeFileType::S_IFDIR.bits() as u32 | permissions) as u16
+    }
+
+    fn special_file_mode(mode: FileMode, file_type: InodeFileType) -> u16 {
+        let permissions = mode.bits() & !FileMode::S_IFMT.bits();
+        (file_type.bits() as u32 | permissions) as u16
+    }
+
+    fn is_device_inode(inode_type: InodeType) -> bool {
+        matches!(inode_type, InodeType::CharDevice | InodeType::BlockDevice)
+    }
+
+    fn read_rdev_from_blocks(block: &[u32; 15]) -> u64 {
+        if block[0] != 0 {
+            decode_ext4_old_dev(block[0])
+        } else {
+            decode_ext4_new_dev(block[1])
+        }
+    }
+
+    fn encoded_rdev_blocks(dev: u64) -> [u32; 15] {
+        let mut blocks = [0; 15];
+        if dev_major(dev) <= 0xff && dev_minor(dev) <= 0xff {
+            blocks[0] = encode_ext4_old_dev(dev);
+        } else {
+            blocks[1] = encode_ext4_new_dev(dev);
+        }
+        blocks
     }
 
     fn read_fast_symlink_target(&self, size: usize) -> Result<Option<String>, FsError> {
@@ -159,7 +211,11 @@ impl Inode for Ext4Inode {
             nlinks: inode.links_count as usize,
             uid: inode.uid as u32,
             gid: inode.gid as u32,
-            rdev: 0,
+            rdev: if Self::is_device_inode(inode_type) {
+                Self::read_rdev_from_blocks(&inode.block)
+            } else {
+                0
+            },
         })
     }
 
@@ -213,7 +269,7 @@ impl Inode for Ext4Inode {
         Ok(Arc::new(Ext4Inode::new(self.fs.clone(), child_ino)))
     }
 
-    fn create(&self, name: &str, _mode: FileMode) -> Result<Arc<dyn Inode>, FsError> {
+    fn create(&self, name: &str, mode: FileMode) -> Result<Arc<dyn Inode>, FsError> {
         // Check if current inode is a directory
         let metadata = self.metadata()?;
         if metadata.inode_type != InodeType::Directory {
@@ -225,15 +281,14 @@ impl Inode for Ext4Inode {
             return Err(FsError::AlreadyExists);
         }
 
-        // create() only creates regular files (not directories)
         let fs = self.fs.lock();
-        // ext4_rs 的 create_inode 内部会强制设置 mode |= 0o777
-        // 所以这里直接使用 0o777
-        let ftype = ext4_rs::InodeFileType::S_IFREG.bits() | 0o777;
+        let file_mode = Self::regular_file_mode(mode);
 
-        let child_inode = fs
-            .create(self.ino, name, ftype)
+        let mut child_inode = fs
+            .create(self.ino, name, file_mode)
             .map_err(|_| FsError::IoError)?;
+        child_inode.inode.set_mode(file_mode);
+        fs.write_back_inode(&mut child_inode);
 
         Ok(Arc::new(Ext4Inode::new(
             self.fs.clone(),
@@ -241,7 +296,7 @@ impl Inode for Ext4Inode {
         )))
     }
 
-    fn mkdir(&self, name: &str, _mode: FileMode) -> Result<Arc<dyn Inode>, FsError> {
+    fn mkdir(&self, name: &str, mode: FileMode) -> Result<Arc<dyn Inode>, FsError> {
         // Check if current inode is a directory
         let metadata = self.metadata()?;
         if metadata.inode_type != InodeType::Directory {
@@ -253,19 +308,21 @@ impl Inode for Ext4Inode {
             return Err(FsError::AlreadyExists);
         }
 
-        // mkdir() creates directories using S_IFDIR | 0o755
         let fs = self.fs.lock();
-        let ftype = ext4_rs::InodeFileType::S_IFDIR.bits() | 0o755;
+        let dir_mode = Self::directory_mode(mode);
 
         let mut parent = self.ino;
         let mut name_off = 0;
 
         let inode_id = fs
-            .generic_open(name, &mut parent, true, ftype, &mut name_off)
+            .generic_open(name, &mut parent, true, dir_mode, &mut name_off)
             .map_err(|e| {
                 crate::pr_debug!("[Ext4Inode::mkdir] generic_open failed: {:?}", e);
                 FsError::NoSpace
             })?;
+        let mut inode_ref = fs.get_inode_ref(inode_id);
+        inode_ref.inode.set_mode(dir_mode);
+        fs.write_back_inode(&mut inode_ref);
 
         Ok(Arc::new(Ext4Inode::new(self.fs.clone(), inode_id)))
     }
@@ -815,8 +872,37 @@ impl Inode for Ext4Inode {
         String::from_utf8(buf).map_err(|_| FsError::InvalidArgument)
     }
 
-    fn mknod(&self, _name: &str, _mode: FileMode, _dev: u64) -> Result<Arc<dyn Inode>, FsError> {
-        // TODO: 实现 ext4 创建文件节点
-        Err(FsError::NotSupported)
+    fn mknod(&self, name: &str, mode: FileMode, dev: u64) -> Result<Arc<dyn Inode>, FsError> {
+        let metadata = self.metadata()?;
+        if metadata.inode_type != InodeType::Directory {
+            return Err(FsError::NotDirectory);
+        }
+
+        if self.lookup(name).is_ok() {
+            return Err(FsError::AlreadyExists);
+        }
+
+        let file_type = Self::mode_file_type(mode)?;
+        let inode_mode = Self::special_file_mode(mode, file_type);
+        let fs = self.fs.lock();
+
+        let mut new_inode = fs
+            .create(self.ino, name, inode_mode)
+            .map_err(|_| FsError::IoError)?;
+
+        new_inode.inode.set_mode(inode_mode);
+        new_inode.inode.set_size(0);
+        new_inode.inode.set_blocks_count(0);
+
+        if matches!(file_type, InodeFileType::S_IFCHR | InodeFileType::S_IFBLK) {
+            new_inode.inode.block = Self::encoded_rdev_blocks(dev);
+        }
+
+        fs.write_back_inode(&mut new_inode);
+
+        Ok(Arc::new(Ext4Inode::new(
+            self.fs.clone(),
+            new_inode.inode_num,
+        )))
     }
 }

--- a/os/src/fs/ext4/inode.rs
+++ b/os/src/fs/ext4/inode.rs
@@ -547,6 +547,14 @@ impl Inode for Ext4Inode {
             // 如果目标已存在，需要先删除它
             let existing_ref = fs.get_inode_ref(existing_ino);
             let replaced_is_dir = existing_ref.inode.is_dir();
+            let old_child_is_dir = old_child_metadata.inode_type == InodeType::Directory;
+
+            if old_child_is_dir && !replaced_is_dir {
+                return Err(FsError::NotDirectory);
+            }
+            if !old_child_is_dir && replaced_is_dir {
+                return Err(FsError::IsDirectory);
+            }
 
             if replaced_is_dir {
                 // 如果目标是目录，必须为空

--- a/os/src/fs/ext4/inode.rs
+++ b/os/src/fs/ext4/inode.rs
@@ -381,7 +381,7 @@ impl Inode for Ext4Inode {
             .ok_or(FsError::InvalidArgument)?;
 
         if !Arc::ptr_eq(&self.fs, &ext4_inode.fs) {
-            return Err(FsError::InvalidArgument);
+            return Err(FsError::CrossDeviceLink);
         }
 
         let fs = self.fs.lock();
@@ -516,7 +516,7 @@ impl Inode for Ext4Inode {
 
         // 确保在同一个文件系统中
         if !Arc::ptr_eq(&self.fs, &new_parent_ext4.fs) {
-            return Err(FsError::InvalidArgument);
+            return Err(FsError::CrossDeviceLink);
         }
 
         // 防止将目录移动到其子目录中（会造成循环）

--- a/os/src/fs/tests/ext4/ext4_metadata.rs
+++ b/os/src/fs/tests/ext4/ext4_metadata.rs
@@ -62,3 +62,114 @@ test_case!(test_ext4_inode_number, {
     let file_metadata = inode.metadata().unwrap();
     kassert!(file_metadata.inode_no != root_metadata.inode_no);
 });
+
+test_case!(test_ext4_create_preserves_file_mode, {
+    let fs = create_test_ext4();
+    let root = fs.root_inode();
+
+    let inode = root
+        .create("private.txt", FileMode::from_bits_truncate(0o600))
+        .unwrap();
+    let metadata = inode.metadata().unwrap();
+
+    kassert!(metadata.inode_type == InodeType::File);
+    kassert!((metadata.mode.bits() & 0o777) == 0o600);
+});
+
+test_case!(test_ext4_mkdir_preserves_mode, {
+    let fs = create_test_ext4();
+    let root = fs.root_inode();
+
+    let inode = root
+        .mkdir("private-dir", FileMode::from_bits_truncate(0o700))
+        .unwrap();
+    let metadata = inode.metadata().unwrap();
+
+    kassert!(metadata.inode_type == InodeType::Directory);
+    kassert!((metadata.mode.bits() & 0o777) == 0o700);
+});
+
+test_case!(test_ext4_mknod_device_metadata, {
+    use crate::vfs::dev::makedev;
+
+    let fs = create_test_ext4();
+    let root = fs.root_inode();
+    let chr_dev = makedev(1, 3);
+    let blk_dev = makedev(254, 16);
+
+    let chr = root
+        .mknod(
+            "null",
+            FileMode::S_IFCHR | FileMode::from_bits_truncate(0o666),
+            chr_dev,
+        )
+        .unwrap();
+    let blk = root
+        .mknod(
+            "vdb",
+            FileMode::S_IFBLK | FileMode::from_bits_truncate(0o660),
+            blk_dev,
+        )
+        .unwrap();
+
+    let chr_meta = chr.metadata().unwrap();
+    let blk_meta = blk.metadata().unwrap();
+    kassert!(chr_meta.inode_type == InodeType::CharDevice);
+    kassert!(chr_meta.rdev == chr_dev);
+    kassert!((chr_meta.mode.bits() & 0o777) == 0o666);
+    kassert!(blk_meta.inode_type == InodeType::BlockDevice);
+    kassert!(blk_meta.rdev == blk_dev);
+    kassert!((blk_meta.mode.bits() & 0o777) == 0o660);
+});
+
+test_case!(test_ext4_mknod_special_file_types, {
+    let fs = create_test_ext4();
+    let root = fs.root_inode();
+
+    let fifo = root
+        .mknod(
+            "fifo",
+            FileMode::S_IFIFO | FileMode::from_bits_truncate(0o644),
+            0,
+        )
+        .unwrap();
+    let sock = root
+        .mknod(
+            "sock",
+            FileMode::S_IFSOCK | FileMode::from_bits_truncate(0o644),
+            0,
+        )
+        .unwrap();
+    let reg = root
+        .mknod(
+            "regular",
+            FileMode::S_IFREG | FileMode::from_bits_truncate(0o600),
+            0,
+        )
+        .unwrap();
+
+    kassert!(fifo.metadata().unwrap().inode_type == InodeType::Fifo);
+    kassert!(sock.metadata().unwrap().inode_type == InodeType::Socket);
+    let reg_meta = reg.metadata().unwrap();
+    kassert!(reg_meta.inode_type == InodeType::File);
+    kassert!((reg_meta.mode.bits() & 0o777) == 0o600);
+});
+
+test_case!(test_ext4_mknod_duplicate, {
+    let fs = create_test_ext4();
+    let root = fs.root_inode();
+
+    root.mknod(
+        "fifo",
+        FileMode::S_IFIFO | FileMode::from_bits_truncate(0o644),
+        0,
+    )
+    .unwrap();
+
+    let result = root.mknod(
+        "fifo",
+        FileMode::S_IFIFO | FileMode::from_bits_truncate(0o644),
+        0,
+    );
+    kassert!(matches!(result, Err(FsError::AlreadyExists)));
+});

--- a/os/src/fs/tests/tmpfs/tmpfs_metadata.rs
+++ b/os/src/fs/tests/tmpfs/tmpfs_metadata.rs
@@ -204,3 +204,57 @@ test_case!(test_tmpfs_metadata_after_unlink, {
     let meta2 = file.metadata();
     kassert!(meta2.is_ok());
 });
+
+test_case!(test_tmpfs_mknod_exact_file_types, {
+    use crate::vfs::dev::makedev;
+
+    let fs = create_test_tmpfs();
+    let root = fs.root_inode();
+    let dev = makedev(254, 16);
+
+    let chr = root
+        .mknod(
+            "ttyS0",
+            FileMode::S_IFCHR | FileMode::from_bits_truncate(0o666),
+            dev,
+        )
+        .unwrap();
+    let blk = root
+        .mknod(
+            "vdb",
+            FileMode::S_IFBLK | FileMode::from_bits_truncate(0o660),
+            dev,
+        )
+        .unwrap();
+    let fifo = root
+        .mknod(
+            "fifo",
+            FileMode::S_IFIFO | FileMode::from_bits_truncate(0o644),
+            0,
+        )
+        .unwrap();
+    let sock = root
+        .mknod(
+            "sock",
+            FileMode::S_IFSOCK | FileMode::from_bits_truncate(0o644),
+            0,
+        )
+        .unwrap();
+    let reg = root
+        .mknod(
+            "regular",
+            FileMode::S_IFREG | FileMode::from_bits_truncate(0o644),
+            0,
+        )
+        .unwrap();
+
+    let chr_meta = chr.metadata().unwrap();
+    let blk_meta = blk.metadata().unwrap();
+    kassert!(chr_meta.inode_type == InodeType::CharDevice);
+    kassert!(chr_meta.rdev == dev);
+    kassert!(blk_meta.inode_type == InodeType::BlockDevice);
+    kassert!(blk_meta.rdev == dev);
+    kassert!(fifo.metadata().unwrap().inode_type == InodeType::Fifo);
+    kassert!(sock.metadata().unwrap().inode_type == InodeType::Socket);
+    kassert!(reg.metadata().unwrap().inode_type == InodeType::File);
+});

--- a/os/src/fs/tmpfs/inode.rs
+++ b/os/src/fs/tmpfs/inode.rs
@@ -191,6 +191,73 @@ impl TmpfsInode {
     fn cancel_page_reservation(&self) {
         self.dec_allocated_pages(1);
     }
+
+    fn remove_link_from_child(&self, child: &Arc<TmpfsInode>) {
+        let (inode_type, should_free_data) = {
+            let mut child_meta = child.metadata.lock();
+            let inode_type = child_meta.inode_type;
+            if inode_type == InodeType::Directory {
+                child_meta.nlinks = 0;
+                child_meta.ctime = TimeSpec::now();
+                (inode_type, false)
+            } else {
+                child_meta.nlinks = child_meta.nlinks.saturating_sub(1);
+                child_meta.ctime = TimeSpec::now();
+                (inode_type, child_meta.nlinks == 0)
+            }
+        };
+
+        if inode_type == InodeType::Directory {
+            let mut meta = self.metadata.lock();
+            meta.nlinks = meta.nlinks.saturating_sub(1);
+        }
+
+        if should_free_data {
+            let child_data = child.data.lock();
+            let allocated = child_data.iter().filter(|f| f.is_some()).count();
+            drop(child_data);
+            self.dec_allocated_pages(allocated);
+        }
+    }
+
+    fn is_descendant_or_self(candidate: &Arc<TmpfsInode>, ancestor: &Arc<TmpfsInode>) -> bool {
+        let mut current = Some(candidate.clone());
+        for _ in 0..1024 {
+            let Some(node) = current else {
+                return false;
+            };
+            if Arc::ptr_eq(&node, ancestor) {
+                return true;
+            }
+            current = node.parent.lock().upgrade();
+        }
+        true
+    }
+
+    fn validate_rename_target(
+        old_child: &Arc<TmpfsInode>,
+        target: &Arc<TmpfsInode>,
+    ) -> Result<(), FsError> {
+        if Arc::ptr_eq(old_child, target) {
+            return Ok(());
+        }
+
+        let old_type = old_child.metadata.lock().inode_type;
+        let target_type = target.metadata.lock().inode_type;
+
+        match (old_type, target_type) {
+            (InodeType::Directory, InodeType::Directory) => {
+                if !target.children.lock().is_empty() {
+                    return Err(FsError::DirectoryNotEmpty);
+                }
+            }
+            (InodeType::Directory, _) => return Err(FsError::NotDirectory),
+            (_, InodeType::Directory) => return Err(FsError::IsDirectory),
+            _ => {}
+        }
+
+        Ok(())
+    }
 }
 
 impl Inode for TmpfsInode {
@@ -451,19 +518,7 @@ impl Inode for TmpfsInode {
         drop(child_meta);
 
         let child = children.remove(name).ok_or(FsError::NotFound)?;
-        let should_free_data = {
-            let mut child_meta = child.metadata.lock();
-            child_meta.nlinks = child_meta.nlinks.saturating_sub(1);
-            child_meta.ctime = TimeSpec::now();
-            child_meta.nlinks == 0
-        };
-
-        if should_free_data {
-            let child_data = child.data.lock();
-            let allocated = child_data.iter().filter(|f| f.is_some()).count();
-            drop(child_data);
-            self.dec_allocated_pages(allocated);
-        }
+        self.remove_link_from_child(&child);
 
         self.update_mtime();
 
@@ -684,12 +739,118 @@ impl Inode for TmpfsInode {
 
     fn rename(
         &self,
-        _old_name: &str,
-        _new_parent: Arc<dyn Inode>,
-        _new_name: &str,
+        old_name: &str,
+        new_parent: Arc<dyn Inode>,
+        new_name: &str,
     ) -> Result<(), FsError> {
-        // TODO: 实现重命名支持
-        Err(FsError::NotSupported)
+        if old_name.is_empty()
+            || new_name.is_empty()
+            || old_name == "."
+            || old_name == ".."
+            || new_name == "."
+            || new_name == ".."
+        {
+            return Err(FsError::InvalidArgument);
+        }
+
+        let meta = self.metadata.lock();
+        if meta.inode_type != InodeType::Directory {
+            return Err(FsError::NotDirectory);
+        }
+        drop(meta);
+
+        let self_arc = self.self_ref.lock().upgrade().ok_or(FsError::IoError)?;
+        let new_parent_ref = new_parent
+            .as_any()
+            .downcast_ref::<TmpfsInode>()
+            .ok_or(FsError::InvalidArgument)?;
+        let new_parent_arc = new_parent_ref
+            .self_ref
+            .lock()
+            .upgrade()
+            .ok_or(FsError::IoError)?;
+
+        if !Arc::ptr_eq(&self.stats, &new_parent_arc.stats) {
+            return Err(FsError::InvalidArgument);
+        }
+
+        let new_parent_meta = new_parent_arc.metadata.lock();
+        if new_parent_meta.inode_type != InodeType::Directory {
+            return Err(FsError::NotDirectory);
+        }
+        drop(new_parent_meta);
+
+        if Arc::ptr_eq(&self_arc, &new_parent_arc) && old_name == new_name {
+            return Ok(());
+        }
+
+        let old_child = {
+            let children = self.children.lock();
+            children.get(old_name).cloned().ok_or(FsError::NotFound)?
+        };
+
+        if old_child.metadata.lock().inode_type == InodeType::Directory
+            && Self::is_descendant_or_self(&new_parent_arc, &old_child)
+        {
+            return Err(FsError::InvalidArgument);
+        }
+
+        if Arc::ptr_eq(&self_arc, &new_parent_arc) {
+            let mut children = self.children.lock();
+            let old_child = children.get(old_name).cloned().ok_or(FsError::NotFound)?;
+            if let Some(target) = children.get(new_name).cloned() {
+                Self::validate_rename_target(&old_child, &target)?;
+                if Arc::ptr_eq(&old_child, &target) {
+                    return Ok(());
+                }
+                children.remove(new_name);
+                self.remove_link_from_child(&target);
+            }
+            let child = children.remove(old_name).ok_or(FsError::NotFound)?;
+            children.insert(new_name.to_string(), child.clone());
+            child.metadata.lock().ctime = TimeSpec::now();
+            drop(children);
+            self.update_mtime();
+            return Ok(());
+        }
+
+        {
+            let new_children = new_parent_arc.children.lock();
+            if let Some(target) = new_children.get(new_name).cloned() {
+                Self::validate_rename_target(&old_child, &target)?;
+                if Arc::ptr_eq(&old_child, &target) {
+                    return Ok(());
+                }
+            }
+        }
+
+        let child = {
+            let mut old_children = self.children.lock();
+            old_children.remove(old_name).ok_or(FsError::NotFound)?
+        };
+
+        {
+            let mut new_children = new_parent_arc.children.lock();
+            if let Some(target) = new_children.remove(new_name) {
+                Self::validate_rename_target(&child, &target)?;
+                new_parent_arc.remove_link_from_child(&target);
+            }
+            new_children.insert(new_name.to_string(), child.clone());
+        }
+
+        if child.metadata.lock().inode_type == InodeType::Directory {
+            *child.parent.lock() = Arc::downgrade(&new_parent_arc);
+            {
+                let mut old_meta = self.metadata.lock();
+                old_meta.nlinks = old_meta.nlinks.saturating_sub(1);
+            }
+            new_parent_arc.metadata.lock().nlinks += 1;
+        }
+        child.metadata.lock().ctime = TimeSpec::now();
+
+        self.update_mtime();
+        new_parent_arc.update_mtime();
+        Ok(())
     }
 
     fn set_times(&self, atime: Option<TimeSpec>, mtime: Option<TimeSpec>) -> Result<(), FsError> {

--- a/os/src/fs/tmpfs/inode.rs
+++ b/os/src/fs/tmpfs/inode.rs
@@ -551,13 +551,8 @@ impl Inode for TmpfsInode {
         }
         drop(child_children);
 
-        // 删除
-        children.remove(name);
-
-        // 更新父目录的 nlinks
-        let mut meta = self.metadata.lock();
-        meta.nlinks = meta.nlinks.saturating_sub(1);
-        drop(meta);
+        let child = children.remove(name).ok_or(FsError::NotFound)?;
+        self.remove_link_from_child(&child);
 
         self.update_mtime();
 

--- a/os/src/fs/tmpfs/inode.rs
+++ b/os/src/fs/tmpfs/inode.rs
@@ -450,14 +450,21 @@ impl Inode for TmpfsInode {
         }
         drop(child_meta);
 
-        // 获取该 inode 的已分配页数
-        let child_data = child.data.lock();
-        let allocated = child_data.iter().filter(|f| f.is_some()).count();
-        drop(child_data);
+        let child = children.remove(name).ok_or(FsError::NotFound)?;
+        let should_free_data = {
+            let mut child_meta = child.metadata.lock();
+            child_meta.nlinks = child_meta.nlinks.saturating_sub(1);
+            child_meta.ctime = TimeSpec::now();
+            child_meta.nlinks == 0
+        };
 
-        // 删除
-        children.remove(name);
-        self.dec_allocated_pages(allocated);
+        if should_free_data {
+            let child_data = child.data.lock();
+            let allocated = child_data.iter().filter(|f| f.is_some()).count();
+            drop(child_data);
+            self.dec_allocated_pages(allocated);
+        }
+
         self.update_mtime();
 
         Ok(())
@@ -637,9 +644,42 @@ impl Inode for TmpfsInode {
         Ok(symlink_inode as Arc<dyn Inode>)
     }
 
-    fn link(&self, _name: &str, _target: &Arc<dyn Inode>) -> Result<(), FsError> {
-        // TODO: 实现硬链接支持
-        Err(FsError::NotSupported)
+    fn link(&self, name: &str, target: &Arc<dyn Inode>) -> Result<(), FsError> {
+        let meta = self.metadata.lock();
+        if meta.inode_type != InodeType::Directory {
+            return Err(FsError::NotDirectory);
+        }
+        drop(meta);
+
+        let target_inode = target
+            .as_any()
+            .downcast_ref::<TmpfsInode>()
+            .ok_or(FsError::InvalidArgument)?;
+        let target_arc = target_inode
+            .self_ref
+            .lock()
+            .upgrade()
+            .ok_or(FsError::IoError)?;
+
+        let mut children = self.children.lock();
+        if children.contains_key(name) {
+            return Err(FsError::AlreadyExists);
+        }
+
+        {
+            let mut target_meta = target_arc.metadata.lock();
+            if target_meta.inode_type == InodeType::Directory {
+                return Err(FsError::PermissionDenied);
+            }
+            target_meta.nlinks += 1;
+            target_meta.ctime = TimeSpec::now();
+        }
+
+        children.insert(name.to_string(), target_arc);
+        drop(children);
+
+        self.update_mtime();
+        Ok(())
     }
 
     fn rename(

--- a/os/src/fs/tmpfs/inode.rs
+++ b/os/src/fs/tmpfs/inode.rs
@@ -698,16 +698,15 @@ impl Inode for TmpfsInode {
             return Err(FsError::AlreadyExists);
         }
 
-        // 从 mode 提取文件类型
-        let inode_type = if mode.contains(FileMode::S_IFCHR) {
-            InodeType::CharDevice
-        } else if mode.contains(FileMode::S_IFBLK) {
-            InodeType::BlockDevice
-        } else if mode.contains(FileMode::S_IFIFO) {
-            InodeType::Fifo
-        } else {
-            // mknod 只支持特殊文件
-            return Err(FsError::InvalidArgument);
+        // 从 mode 的类型掩码精确提取文件类型。文件类型位不是互斥 bitflags，
+        // 不能用 contains() 判断，否则 S_IFBLK 会被误判成 S_IFCHR。
+        let inode_type = match mode & FileMode::S_IFMT {
+            FileMode::S_IFCHR => InodeType::CharDevice,
+            FileMode::S_IFBLK => InodeType::BlockDevice,
+            FileMode::S_IFIFO => InodeType::Fifo,
+            FileMode::S_IFSOCK => InodeType::Socket,
+            FileMode::S_IFREG => InodeType::File,
+            _ => return Err(FsError::InvalidArgument),
         };
 
         // 分配新的 inode 号

--- a/os/src/fs/tmpfs/inode.rs
+++ b/os/src/fs/tmpfs/inode.rs
@@ -709,7 +709,7 @@ impl Inode for TmpfsInode {
         let target_inode = target
             .as_any()
             .downcast_ref::<TmpfsInode>()
-            .ok_or(FsError::InvalidArgument)?;
+            .ok_or(FsError::CrossDeviceLink)?;
         let target_arc = target_inode
             .self_ref
             .lock()
@@ -763,7 +763,7 @@ impl Inode for TmpfsInode {
         let new_parent_ref = new_parent
             .as_any()
             .downcast_ref::<TmpfsInode>()
-            .ok_or(FsError::InvalidArgument)?;
+            .ok_or(FsError::CrossDeviceLink)?;
         let new_parent_arc = new_parent_ref
             .self_ref
             .lock()
@@ -771,7 +771,7 @@ impl Inode for TmpfsInode {
             .ok_or(FsError::IoError)?;
 
         if !Arc::ptr_eq(&self.stats, &new_parent_arc.stats) {
-            return Err(FsError::InvalidArgument);
+            return Err(FsError::CrossDeviceLink);
         }
 
         let new_parent_meta = new_parent_arc.metadata.lock();

--- a/os/src/fs/vfat/inode.rs
+++ b/os/src/fs/vfat/inode.rs
@@ -235,11 +235,11 @@ impl Inode for VfatInode {
         let new_parent = new_parent
             .as_any()
             .downcast_ref::<VfatInode>()
-            .ok_or(FsError::InvalidArgument)?;
+            .ok_or(FsError::CrossDeviceLink)?;
         new_parent.ensure_directory()?;
 
         if !Arc::ptr_eq(&self.state, &new_parent.state) {
-            return Err(FsError::InvalidArgument);
+            return Err(FsError::CrossDeviceLink);
         }
 
         if self.path == new_parent.path && old_name.eq_ignore_ascii_case(new_name) {

--- a/os/src/kernel/syscall/dispatch.rs
+++ b/os/src/kernel/syscall/dispatch.rs
@@ -36,6 +36,7 @@ pub fn dispatch_syscall(frame: &mut impl SyscallFrame) {
         crate::kernel::syscall::numbers::SYS_MKDIRAT => sys_mkdirat(frame),
         crate::kernel::syscall::numbers::SYS_UNLINKAT => sys_unlinkat(frame),
         crate::kernel::syscall::numbers::SYS_SYMLINKAT => sys_symlinkat(frame),
+        crate::kernel::syscall::numbers::SYS_LINKAT => sys_linkat(frame),
 
         // 挂载/文件系统信息
         crate::kernel::syscall::numbers::SYS_MOUNT => sys_mount(frame),

--- a/os/src/kernel/syscall/dispatch.rs
+++ b/os/src/kernel/syscall/dispatch.rs
@@ -145,6 +145,7 @@ pub fn dispatch_syscall(frame: &mut impl SyscallFrame) {
 
         // 网络
         crate::kernel::syscall::numbers::SYS_SOCKET => sys_socket(frame),
+        crate::kernel::syscall::numbers::SYS_SOCKETPAIR => sys_socketpair(frame),
         crate::kernel::syscall::numbers::SYS_BIND => sys_bind(frame),
         crate::kernel::syscall::numbers::SYS_LISTEN => sys_listen(frame),
         crate::kernel::syscall::numbers::SYS_ACCEPT => sys_accept(frame),

--- a/os/src/kernel/syscall/fcntl.rs
+++ b/os/src/kernel/syscall/fcntl.rs
@@ -274,7 +274,7 @@ pub fn fcntl(fd: usize, cmd_raw: i32, arg: usize) -> isize {
             };
 
             match file.set_pipe_size(new_size) {
-                Ok(()) => new_size as isize,
+                Ok(size) => size as isize,
                 Err(e) => e.to_errno(),
             }
         }

--- a/os/src/kernel/syscall/fs/metadata_ops.rs
+++ b/os/src/kernel/syscall/fs/metadata_ops.rs
@@ -59,6 +59,9 @@ pub fn fchownat(dirfd: i32, pathname: *const c_char, owner: u32, group: u32, fla
             Err(e) => e.to_errno(),
         };
     }
+    if path_str.is_empty() {
+        return FsError::NotFound.to_errno();
+    }
 
     // 解析路径，获取 dentry（使用辅助函数）
     let dentry = match resolve_at_path_with_flags(dirfd, &path_str, follow_symlink) {
@@ -104,6 +107,9 @@ pub fn fchmodat(dirfd: i32, pathname: *const c_char, mode: u32, flags: u32) -> i
     // 解析标志位
     let at_flags = AtFlags::from_bits_retain(flags);
     let follow_symlink = !at_flags.contains(AtFlags::SYMLINK_NOFOLLOW);
+    if path_str.is_empty() {
+        return FsError::NotFound.to_errno();
+    }
 
     // 验证 mode 参数（只保留权限位，去除文件类型位）
     let mode = mode & 0o7777; // 保留 12 位权限位（包括 setuid/setgid/sticky）

--- a/os/src/kernel/syscall/fs/metadata_ops.rs
+++ b/os/src/kernel/syscall/fs/metadata_ops.rs
@@ -1,4 +1,32 @@
 use super::*;
+use alloc::string::String;
+
+fn split_creating_path(dirfd: i32, path: &str) -> Result<(String, String), FsError> {
+    if path.bytes().all(|b| b == b'/') {
+        return Err(FsError::AlreadyExists);
+    }
+    if path.ends_with('/') {
+        let path = path.trim_end_matches('/');
+        match resolve_at_path(dirfd, path) {
+            Ok(Some(_)) => return Err(FsError::AlreadyExists),
+            Ok(None) => {}
+            Err(e) => return Err(e),
+        }
+
+        let (parent, _) = split_parent_preserving_basename(path)?;
+        let parent = match resolve_at_path(dirfd, &parent)? {
+            Some(parent) => parent,
+            None => return Err(FsError::NotFound),
+        };
+        if parent.inode.metadata()?.inode_type != InodeType::Directory {
+            return Err(FsError::NotDirectory);
+        }
+
+        return Err(FsError::NotFound);
+    }
+
+    split_parent_preserving_basename(path)
+}
 
 /// fchownat - 修改文件所有者和组
 ///
@@ -150,7 +178,7 @@ pub fn mknodat(dirfd: i32, pathname: *const c_char, mode: u32, dev: u64) -> isiz
     };
 
     // 分割路径为目录和文件名
-    let (dir_path, filename) = match split_parent_preserving_basename(&path_str) {
+    let (dir_path, filename) = match split_creating_path(dirfd, &path_str) {
         Ok(p) => p,
         Err(e) => return e.to_errno(),
     };
@@ -221,7 +249,7 @@ pub fn symlinkat(target: *const c_char, newdirfd: i32, linkpath: *const c_char) 
     };
 
     // 分割路径为目录和文件名
-    let (dir_path, link_name) = match split_parent_preserving_basename(&link_str) {
+    let (dir_path, link_name) = match split_creating_path(newdirfd, &link_str) {
         Ok(p) => p,
         Err(e) => return e.to_errno(),
     };
@@ -288,7 +316,7 @@ pub fn linkat(
         return -(crate::uapi::errno::EPERM as isize);
     }
 
-    let (new_dir_path, new_name) = match split_parent_preserving_basename(&new_path) {
+    let (new_dir_path, new_name) = match split_creating_path(newdirfd, &new_path) {
         Ok(parts) => parts,
         Err(e) => return e.to_errno(),
     };

--- a/os/src/kernel/syscall/fs/metadata_ops.rs
+++ b/os/src/kernel/syscall/fs/metadata_ops.rs
@@ -260,6 +260,9 @@ pub fn linkat(
         Ok(s) => s,
         Err(e) => return e.to_errno(),
     };
+    if old_path.is_empty() {
+        return FsError::NotFound.to_errno();
+    }
 
     const LINKAT_ALLOWED_FLAGS: u32 = crate::uapi::fs::AtFlags::SYMLINK_FOLLOW.bits();
     if flags & !LINKAT_ALLOWED_FLAGS != 0 {

--- a/os/src/kernel/syscall/fs/metadata_ops.rs
+++ b/os/src/kernel/syscall/fs/metadata_ops.rs
@@ -148,8 +148,14 @@ pub fn mknodat(dirfd: i32, pathname: *const c_char, mode: u32, dev: u64) -> isiz
     // 构造文件模式
     let file_mode = FileMode::from_bits_truncate(mode);
 
+    // 用户态传入的是 Linux ABI dev_t，VFS 内部使用自己的 major/minor 编码。
+    let internal_dev = crate::vfs::dev::decode_linux_dev(dev);
+
     // 调用 inode.mknod()
-    match parent_dentry.inode.mknod(&filename, file_mode, dev) {
+    match parent_dentry
+        .inode
+        .mknod(&filename, file_mode, internal_dev)
+    {
         Ok(child_inode) => {
             // 创建 dentry 并加入缓存
             let child_dentry = Dentry::new(filename.clone(), child_inode);

--- a/os/src/kernel/syscall/fs/metadata_ops.rs
+++ b/os/src/kernel/syscall/fs/metadata_ops.rs
@@ -144,7 +144,7 @@ pub fn mknodat(dirfd: i32, pathname: *const c_char, mode: u32, dev: u64) -> isiz
     };
 
     // 分割路径为目录和文件名
-    let (dir_path, filename) = match split_path(&path_str) {
+    let (dir_path, filename) = match split_parent_preserving_basename(&path_str) {
         Ok(p) => p,
         Err(e) => return e.to_errno(),
     };
@@ -155,6 +155,10 @@ pub fn mknodat(dirfd: i32, pathname: *const c_char, mode: u32, dev: u64) -> isiz
         Ok(None) => return FsError::NotFound.to_errno(),
         Err(e) => return e.to_errno(),
     };
+
+    if is_special_basename(&filename) {
+        return FsError::AlreadyExists.to_errno();
+    }
 
     // 构造文件模式
     let file_mode = FileMode::from_bits_truncate(mode);
@@ -205,7 +209,7 @@ pub fn symlinkat(target: *const c_char, newdirfd: i32, linkpath: *const c_char) 
     };
 
     // 分割路径为目录和文件名
-    let (dir_path, link_name) = match split_path(&link_str) {
+    let (dir_path, link_name) = match split_parent_preserving_basename(&link_str) {
         Ok(p) => p,
         Err(e) => return e.to_errno(),
     };
@@ -216,6 +220,10 @@ pub fn symlinkat(target: *const c_char, newdirfd: i32, linkpath: *const c_char) 
         Ok(None) => return FsError::NotFound.to_errno(),
         Err(e) => return e.to_errno(),
     };
+
+    if is_special_basename(&link_name) {
+        return FsError::AlreadyExists.to_errno();
+    }
 
     // 创建符号链接
     match parent_dentry.inode.symlink(&link_name, &target_str) {
@@ -265,7 +273,7 @@ pub fn linkat(
         return -(crate::uapi::errno::EPERM as isize);
     }
 
-    let (new_dir_path, new_name) = match split_path(&new_path) {
+    let (new_dir_path, new_name) = match split_parent_preserving_basename(&new_path) {
         Ok(parts) => parts,
         Err(e) => return e.to_errno(),
     };
@@ -280,6 +288,9 @@ pub fn linkat(
     };
     if new_parent_meta.inode_type != InodeType::Directory {
         return FsError::NotDirectory.to_errno();
+    }
+    if is_special_basename(&new_name) {
+        return FsError::AlreadyExists.to_errno();
     }
 
     match new_parent.inode.link(&new_name, &old_dentry.inode) {

--- a/os/src/kernel/syscall/fs/metadata_ops.rs
+++ b/os/src/kernel/syscall/fs/metadata_ops.rs
@@ -24,8 +24,14 @@ pub fn fchownat(dirfd: i32, pathname: *const c_char, owner: u32, group: u32, fla
         Err(e) => return e.to_errno(),
     };
 
+    const FCHOWNAT_ALLOWED_FLAGS: u32 =
+        AtFlags::SYMLINK_NOFOLLOW.bits() | AtFlags::EMPTY_PATH.bits();
+    if flags & !FCHOWNAT_ALLOWED_FLAGS != 0 {
+        return -(EINVAL as isize);
+    }
+
     // 解析标志位
-    let at_flags = AtFlags::from_bits_truncate(flags);
+    let at_flags = AtFlags::from_bits_retain(flags);
     let follow_symlink = !at_flags.contains(AtFlags::SYMLINK_NOFOLLOW);
     let empty_path = at_flags.contains(AtFlags::EMPTY_PATH);
 
@@ -90,8 +96,13 @@ pub fn fchmodat(dirfd: i32, pathname: *const c_char, mode: u32, flags: u32) -> i
         Err(e) => return e.to_errno(),
     };
 
+    const FCHMODAT_ALLOWED_FLAGS: u32 = AtFlags::SYMLINK_NOFOLLOW.bits();
+    if flags & !FCHMODAT_ALLOWED_FLAGS != 0 {
+        return -(EINVAL as isize);
+    }
+
     // 解析标志位
-    let at_flags = AtFlags::from_bits_truncate(flags);
+    let at_flags = AtFlags::from_bits_retain(flags);
     let follow_symlink = !at_flags.contains(AtFlags::SYMLINK_NOFOLLOW);
 
     // 验证 mode 参数（只保留权限位，去除文件类型位）

--- a/os/src/kernel/syscall/fs/metadata_ops.rs
+++ b/os/src/kernel/syscall/fs/metadata_ops.rs
@@ -227,8 +227,6 @@ pub fn linkat(
     newpath: *const c_char,
     flags: u32,
 ) -> isize {
-    use crate::uapi::fs::AtFlags;
-
     let old_path = match get_path_safe(oldpath as usize) {
         Ok(s) => s,
         Err(e) => return e.to_errno(),
@@ -238,15 +236,12 @@ pub fn linkat(
         Err(e) => return e.to_errno(),
     };
 
-    let at_flags = match AtFlags::from_bits(flags) {
-        Some(flags) => flags,
-        None => return -(EINVAL as isize),
-    };
-    if at_flags.contains(AtFlags::EMPTY_PATH) {
+    const LINKAT_ALLOWED_FLAGS: u32 = crate::uapi::fs::AtFlags::SYMLINK_FOLLOW.bits();
+    if flags & !LINKAT_ALLOWED_FLAGS != 0 {
         return -(EINVAL as isize);
     }
 
-    let follow_symlink = at_flags.contains(AtFlags::SYMLINK_FOLLOW);
+    let follow_symlink = flags & crate::uapi::fs::AtFlags::SYMLINK_FOLLOW.bits() != 0;
     let old_dentry = match resolve_at_path_with_flags(olddirfd, &old_path, follow_symlink) {
         Ok(dentry) => dentry,
         Err(e) => return e.to_errno(),

--- a/os/src/kernel/syscall/fs/metadata_ops.rs
+++ b/os/src/kernel/syscall/fs/metadata_ops.rs
@@ -171,6 +171,9 @@ pub fn mknodat(dirfd: i32, pathname: *const c_char, mode: u32, dev: u64) -> isiz
     if file_mode & FileMode::S_IFMT == FileMode::empty() {
         file_mode |= FileMode::S_IFREG;
     }
+    if file_mode & FileMode::S_IFMT == FileMode::S_IFDIR {
+        return -(crate::uapi::errno::EPERM as isize);
+    }
 
     // 用户态传入的是 Linux ABI dev_t，VFS 内部使用自己的 major/minor 编码。
     let internal_dev = crate::vfs::dev::decode_linux_dev(dev);

--- a/os/src/kernel/syscall/fs/metadata_ops.rs
+++ b/os/src/kernel/syscall/fs/metadata_ops.rs
@@ -218,3 +218,72 @@ pub fn symlinkat(target: *const c_char, newdirfd: i32, linkpath: *const c_char) 
         Err(e) => e.to_errno(),
     }
 }
+
+/// linkat - 创建硬链接
+pub fn linkat(
+    olddirfd: i32,
+    oldpath: *const c_char,
+    newdirfd: i32,
+    newpath: *const c_char,
+    flags: u32,
+) -> isize {
+    use crate::uapi::fs::AtFlags;
+
+    let old_path = match get_path_safe(oldpath as usize) {
+        Ok(s) => s,
+        Err(e) => return e.to_errno(),
+    };
+    let new_path = match get_path_safe(newpath as usize) {
+        Ok(s) => s,
+        Err(e) => return e.to_errno(),
+    };
+
+    let at_flags = match AtFlags::from_bits(flags) {
+        Some(flags) => flags,
+        None => return -(EINVAL as isize),
+    };
+    if at_flags.contains(AtFlags::EMPTY_PATH) {
+        return -(EINVAL as isize);
+    }
+
+    let follow_symlink = at_flags.contains(AtFlags::SYMLINK_FOLLOW);
+    let old_dentry = match resolve_at_path_with_flags(olddirfd, &old_path, follow_symlink) {
+        Ok(dentry) => dentry,
+        Err(e) => return e.to_errno(),
+    };
+    let old_meta = match old_dentry.inode.metadata() {
+        Ok(meta) => meta,
+        Err(e) => return e.to_errno(),
+    };
+    if old_meta.inode_type == InodeType::Directory {
+        return -(crate::uapi::errno::EPERM as isize);
+    }
+
+    let (new_dir_path, new_name) = match split_path(&new_path) {
+        Ok(parts) => parts,
+        Err(e) => return e.to_errno(),
+    };
+    let new_parent = match resolve_at_path(newdirfd, &new_dir_path) {
+        Ok(Some(dentry)) => dentry,
+        Ok(None) => return FsError::NotFound.to_errno(),
+        Err(e) => return e.to_errno(),
+    };
+    let new_parent_meta = match new_parent.inode.metadata() {
+        Ok(meta) => meta,
+        Err(e) => return e.to_errno(),
+    };
+    if new_parent_meta.inode_type != InodeType::Directory {
+        return FsError::NotDirectory.to_errno();
+    }
+
+    match new_parent.inode.link(&new_name, &old_dentry.inode) {
+        Ok(()) => {
+            drop_cached_child(&new_parent, &new_name);
+            let link_dentry = Dentry::new(new_name, old_dentry.inode.clone());
+            new_parent.add_child(link_dentry.clone());
+            DENTRY_CACHE.insert(&link_dentry);
+            0
+        }
+        Err(e) => e.to_errno(),
+    }
+}

--- a/os/src/kernel/syscall/fs/metadata_ops.rs
+++ b/os/src/kernel/syscall/fs/metadata_ops.rs
@@ -110,7 +110,7 @@ pub fn fchownat(dirfd: i32, pathname: *const c_char, owner: u32, group: u32, fla
 /// * `dirfd` - 目录文件描述符（AT_FDCWD 表示当前目录）
 /// * `pathname` - 文件路径
 /// * `mode` - 新的权限模式（12 位权限位）
-/// * `flags` - 标志位（AT_SYMLINK_NOFOLLOW 等）
+/// * `flags` - 标志位（AT_SYMLINK_NOFOLLOW、AT_EMPTY_PATH 等）
 ///
 /// # 返回值
 /// * 0 - 成功
@@ -127,7 +127,8 @@ pub fn fchmodat(dirfd: i32, pathname: *const c_char, mode: u32, flags: u32) -> i
         Err(e) => return e.to_errno(),
     };
 
-    const FCHMODAT_ALLOWED_FLAGS: u32 = AtFlags::SYMLINK_NOFOLLOW.bits();
+    const FCHMODAT_ALLOWED_FLAGS: u32 =
+        AtFlags::SYMLINK_NOFOLLOW.bits() | AtFlags::EMPTY_PATH.bits();
     if flags & !FCHMODAT_ALLOWED_FLAGS != 0 {
         return -(EINVAL as isize);
     }
@@ -135,9 +136,7 @@ pub fn fchmodat(dirfd: i32, pathname: *const c_char, mode: u32, flags: u32) -> i
     // 解析标志位
     let at_flags = AtFlags::from_bits_retain(flags);
     let follow_symlink = !at_flags.contains(AtFlags::SYMLINK_NOFOLLOW);
-    if path_str.is_empty() {
-        return FsError::NotFound.to_errno();
-    }
+    let empty_path = at_flags.contains(AtFlags::EMPTY_PATH);
 
     // 验证 mode 参数（只保留权限位，去除文件类型位）
     let mode = mode & 0o7777; // 保留 12 位权限位（包括 setuid/setgid/sticky）
@@ -145,6 +144,34 @@ pub fn fchmodat(dirfd: i32, pathname: *const c_char, mode: u32, flags: u32) -> i
         Some(m) => m,
         None => return -(EINVAL as isize),
     };
+
+    // 处理 AT_EMPTY_PATH 情况
+    if empty_path && path_str.is_empty() {
+        // pathname 为空，操作 dirfd 本身
+        if dirfd == AT_FDCWD {
+            // 不能对当前目录使用 AT_EMPTY_PATH
+            return -(EINVAL as isize);
+        }
+
+        let task = current_task();
+        let file = match task.lock().fd_table.get(dirfd as usize) {
+            Ok(f) => f,
+            Err(e) => return e.to_errno(),
+        };
+
+        let dentry = match file.dentry() {
+            Ok(d) => d,
+            Err(e) => return e.to_errno(),
+        };
+
+        return match dentry.inode.chmod(file_mode) {
+            Ok(()) => 0,
+            Err(e) => e.to_errno(),
+        };
+    }
+    if path_str.is_empty() {
+        return FsError::NotFound.to_errno();
+    }
 
     // 解析路径，获取 dentry（使用辅助函数）
     let dentry = match resolve_at_path_with_flags(dirfd, &path_str, follow_symlink) {

--- a/os/src/kernel/syscall/fs/metadata_ops.rs
+++ b/os/src/kernel/syscall/fs/metadata_ops.rs
@@ -166,8 +166,11 @@ pub fn mknodat(dirfd: i32, pathname: *const c_char, mode: u32, dev: u64) -> isiz
         return FsError::AlreadyExists.to_errno();
     }
 
-    // 构造文件模式
-    let file_mode = FileMode::from_bits_truncate(mode);
+    // mknod without an explicit file type creates a regular file.
+    let mut file_mode = FileMode::from_bits_truncate(mode);
+    if file_mode & FileMode::S_IFMT == FileMode::empty() {
+        file_mode |= FileMode::S_IFREG;
+    }
 
     // 用户态传入的是 Linux ABI dev_t，VFS 内部使用自己的 major/minor 编码。
     let internal_dev = crate::vfs::dev::decode_linux_dev(dev);

--- a/os/src/kernel/syscall/fs/mod.rs
+++ b/os/src/kernel/syscall/fs/mod.rs
@@ -20,8 +20,8 @@ use crate::{
     },
     util::user_buffer::write_to_user,
     vfs::{
-        DENTRY_CACHE, Dentry, FileMode, FsError, InodeType, OpenFlags, SeekWhence, Stat, Statx,
-        split_path, vfs_lookup,
+        DENTRY_CACHE, Dentry, FdFlags, FileMode, FsError, InodeType, OpenFlags, SeekWhence, Stat,
+        Statx, split_path, vfs_lookup,
     },
 };
 

--- a/os/src/kernel/syscall/fs/mod.rs
+++ b/os/src/kernel/syscall/fs/mod.rs
@@ -8,8 +8,9 @@ use crate::{
     kernel::{
         current_task,
         syscall::util::{
-            create_file_at, create_file_from_dentry, get_path_safe, resolve_at_path,
-            resolve_at_path_string, resolve_at_path_with_flags,
+            create_file_at, create_file_from_dentry, get_path_safe, is_special_basename,
+            resolve_at_path, resolve_at_path_string, resolve_at_path_with_flags,
+            split_parent_preserving_basename,
         },
     },
     uapi::{

--- a/os/src/kernel/syscall/fs/mod.rs
+++ b/os/src/kernel/syscall/fs/mod.rs
@@ -21,7 +21,7 @@ use crate::{
     util::user_buffer::write_to_user,
     vfs::{
         DENTRY_CACHE, Dentry, FdFlags, FileMode, FsError, InodeType, OpenFlags, SeekWhence, Stat,
-        Statx, split_path, vfs_lookup,
+        Statx, vfs_lookup,
     },
 };
 

--- a/os/src/kernel/syscall/fs/mod.rs
+++ b/os/src/kernel/syscall/fs/mod.rs
@@ -29,6 +29,12 @@ pub const AT_SYMLINK_NOFOLLOW: u32 = 0x100;
 pub const AT_REMOVEDIR: u32 = 0x200;
 pub const O_CLOEXEC: u32 = 0o2000000;
 
+fn drop_cached_child(parent: &Dentry, name: &str) {
+    if let Some(child) = parent.remove_child(name) {
+        DENTRY_CACHE.remove(&child.full_path());
+    }
+}
+
 mod fd_ops;
 mod metadata_ops;
 mod mount_ops;

--- a/os/src/kernel/syscall/fs/path_ops.rs
+++ b/os/src/kernel/syscall/fs/path_ops.rs
@@ -238,7 +238,7 @@ pub fn getcwd(buf: *mut u8, size: usize) -> isize {
 
     // 检查缓冲区大小
     if path_bytes.len() + 1 > size {
-        return FsError::InvalidArgument.to_errno();
+        return -(crate::uapi::errno::ERANGE as isize);
     }
 
     // 复制到用户态缓冲区

--- a/os/src/kernel/syscall/fs/path_ops.rs
+++ b/os/src/kernel/syscall/fs/path_ops.rs
@@ -25,9 +25,11 @@ pub fn openat(dirfd: i32, pathname: *const c_char, flags: u32, mode: u32) -> isi
         return FsError::InvalidArgument.to_errno();
     }
 
+    let follow_symlink = !open_flags.contains(OpenFlags::O_NOFOLLOW);
+
     // 解析路径（处理AT_FDCWD和相对路径）
-    let dentry = match resolve_at_path(dirfd, &path_str) {
-        Ok(Some(d)) => {
+    let dentry = match resolve_at_path_with_flags(dirfd, &path_str, follow_symlink) {
+        Ok(d) => {
             // 文件已存在
             // 检查 O_EXCL (与 O_CREAT 一起使用时，文件必须不存在)
             if open_flags.contains(OpenFlags::O_CREAT) && open_flags.contains(OpenFlags::O_EXCL) {
@@ -35,7 +37,7 @@ pub fn openat(dirfd: i32, pathname: *const c_char, flags: u32, mode: u32) -> isi
             }
             d
         }
-        Ok(None) => {
+        Err(FsError::NotFound) => {
             // 文件不存在，检查是否需要创建
             if !open_flags.contains(OpenFlags::O_CREAT) {
                 return FsError::NotFound.to_errno();
@@ -55,6 +57,13 @@ pub fn openat(dirfd: i32, pathname: *const c_char, flags: u32, mode: u32) -> isi
         Ok(m) => m,
         Err(e) => return e.to_errno(),
     };
+
+    if open_flags.contains(OpenFlags::O_NOFOLLOW) && meta.inode_type == InodeType::Symlink {
+        if open_flags.contains(OpenFlags::O_DIRECTORY) {
+            return FsError::NotDirectory.to_errno();
+        }
+        return FsError::TooManySymlinks.to_errno();
+    }
 
     // 检查 O_DIRECTORY (必须是目录)
     if open_flags.contains(OpenFlags::O_DIRECTORY) && meta.inode_type != InodeType::Directory {

--- a/os/src/kernel/syscall/fs/path_ops.rs
+++ b/os/src/kernel/syscall/fs/path_ops.rs
@@ -106,6 +106,10 @@ pub fn mkdirat(dirfd: i32, pathname: *const c_char, mode: u32) -> isize {
 }
 
 pub fn unlinkat(dirfd: i32, pathname: *const c_char, flags: u32) -> isize {
+    if flags & !AT_REMOVEDIR != 0 {
+        return FsError::InvalidArgument.to_errno();
+    }
+
     // 解析路径
     let path_str = match get_path_safe(pathname as usize) {
         Ok(s) => s,
@@ -152,7 +156,13 @@ pub fn unlinkat(dirfd: i32, pathname: *const c_char, flags: u32) -> isize {
     }
 
     // 删除目录项
-    match parent_dentry.inode.unlink(&filename) {
+    let result = if is_rmdir {
+        parent_dentry.inode.rmdir(&filename)
+    } else {
+        parent_dentry.inode.unlink(&filename)
+    };
+
+    match result {
         Ok(()) => {
             // 从缓存中移除
             drop_cached_child(&parent_dentry, &filename);

--- a/os/src/kernel/syscall/fs/path_ops.rs
+++ b/os/src/kernel/syscall/fs/path_ops.rs
@@ -100,6 +100,11 @@ pub fn mkdirat(dirfd: i32, pathname: *const c_char, mode: u32) -> isize {
         Ok(s) => s,
         Err(e) => return e.to_errno(),
     };
+    let path_str = if path_str.bytes().all(|b| b == b'/') {
+        path_str
+    } else {
+        path_str.trim_end_matches('/').into()
+    };
 
     // 分割路径为目录和文件名
     let (dir_path, dirname) = match split_parent_preserving_basename(&path_str) {

--- a/os/src/kernel/syscall/fs/path_ops.rs
+++ b/os/src/kernel/syscall/fs/path_ops.rs
@@ -18,6 +18,10 @@ pub fn openat(dirfd: i32, pathname: *const c_char, flags: u32, mode: u32) -> isi
 
     // crate::println!("[openat] path: {}, flags: {:?} (raw: 0x{:x})", path_str, open_flags, flags);
 
+    if open_flags.contains(OpenFlags::O_CREAT) && open_flags.contains(OpenFlags::O_DIRECTORY) {
+        return FsError::InvalidArgument.to_errno();
+    }
+
     // 解析路径（处理AT_FDCWD和相对路径）
     let dentry = match resolve_at_path(dirfd, &path_str) {
         Ok(Some(d)) => {

--- a/os/src/kernel/syscall/fs/path_ops.rs
+++ b/os/src/kernel/syscall/fs/path_ops.rs
@@ -89,7 +89,7 @@ pub fn mkdirat(dirfd: i32, pathname: *const c_char, mode: u32) -> isize {
     };
 
     // 分割路径为目录和文件名
-    let (dir_path, dirname) = match split_path(&path_str) {
+    let (dir_path, dirname) = match split_parent_preserving_basename(&path_str) {
         Ok(p) => p,
         Err(e) => return e.to_errno(),
     };
@@ -100,6 +100,10 @@ pub fn mkdirat(dirfd: i32, pathname: *const c_char, mode: u32) -> isize {
         Ok(None) => return FsError::NotFound.to_errno(),
         Err(e) => return e.to_errno(),
     };
+
+    if is_special_basename(&dirname) {
+        return FsError::AlreadyExists.to_errno();
+    }
 
     // 创建目录
     let dir_mode = FileMode::from_bits_truncate(mode) | FileMode::S_IFDIR;
@@ -123,7 +127,7 @@ pub fn unlinkat(dirfd: i32, pathname: *const c_char, flags: u32) -> isize {
     let is_rmdir = (flags & AT_REMOVEDIR) != 0;
 
     // 分割路径
-    let (dir_path, filename) = match split_path(&path_str) {
+    let (dir_path, filename) = match split_parent_preserving_basename(&path_str) {
         Ok(p) => p,
         Err(e) => return e.to_errno(),
     };
@@ -134,6 +138,10 @@ pub fn unlinkat(dirfd: i32, pathname: *const c_char, flags: u32) -> isize {
         Ok(None) => return FsError::NotFound.to_errno(),
         Err(e) => return e.to_errno(),
     };
+
+    if is_rmdir && filename == "." {
+        return FsError::InvalidArgument.to_errno();
+    }
 
     // 检查目标文件类型
     let target_inode = match parent_dentry.inode.lookup(&filename) {

--- a/os/src/kernel/syscall/fs/path_ops.rs
+++ b/os/src/kernel/syscall/fs/path_ops.rs
@@ -87,7 +87,8 @@ pub fn openat(dirfd: i32, pathname: *const c_char, flags: u32, mode: u32) -> isi
 
     // 分配文件描述符
     let task = current_task();
-    match task.lock().fd_table.alloc(file) {
+    let fd_flags = FdFlags::from_open_flags(open_flags);
+    match task.lock().fd_table.alloc_with_flags(file, fd_flags) {
         Ok(fd) => fd as isize,
         Err(e) => e.to_errno(),
     }

--- a/os/src/kernel/syscall/fs/path_ops.rs
+++ b/os/src/kernel/syscall/fs/path_ops.rs
@@ -7,6 +7,9 @@ pub fn openat(dirfd: i32, pathname: *const c_char, flags: u32, mode: u32) -> isi
         Ok(s) => s,
         Err(e) => return e.to_errno(),
     };
+    if path_str.is_empty() {
+        return FsError::NotFound.to_errno();
+    }
 
     // 解析标志位
     let open_flags = match OpenFlags::from_bits(flags) {

--- a/os/src/kernel/syscall/fs/path_ops.rs
+++ b/os/src/kernel/syscall/fs/path_ops.rs
@@ -155,7 +155,7 @@ pub fn unlinkat(dirfd: i32, pathname: *const c_char, flags: u32) -> isize {
     match parent_dentry.inode.unlink(&filename) {
         Ok(()) => {
             // 从缓存中移除
-            parent_dentry.remove_child(&filename);
+            drop_cached_child(&parent_dentry, &filename);
             0
         }
         Err(e) => e.to_errno(),

--- a/os/src/kernel/syscall/fs/rename_ops.rs
+++ b/os/src/kernel/syscall/fs/rename_ops.rs
@@ -285,9 +285,9 @@ pub fn renameat2(
         );
 
         // 更新 dentry 缓存
-        old_parent.remove_child(&old_name);
-        old_parent.remove_child(&temp_name);
-        new_parent.remove_child(&new_name);
+        drop_cached_child(&old_parent, &old_name);
+        drop_cached_child(&old_parent, &temp_name);
+        drop_cached_child(&new_parent, &new_name);
     } else if rename_flags.contains(RenameFlags::NOREPLACE) {
         // 目标存在时失败
         if new_parent.inode.lookup(&new_name).is_ok() {
@@ -303,7 +303,7 @@ pub fn renameat2(
         }
 
         // 更新 dentry 缓存
-        old_parent.remove_child(&old_name);
+        drop_cached_child(&old_parent, &old_name);
     } else if rename_flags.contains(RenameFlags::WHITEOUT) {
         // WHITEOUT 暂不支持(需要 Union FS 支持)
         return FsError::NotSupported.to_errno();
@@ -317,8 +317,8 @@ pub fn renameat2(
         }
 
         // 更新 dentry 缓存
-        old_parent.remove_child(&old_name);
-        new_parent.remove_child(&new_name);
+        drop_cached_child(&old_parent, &old_name);
+        drop_cached_child(&new_parent, &new_name);
     }
 
     0

--- a/os/src/kernel/syscall/fs/rename_ops.rs
+++ b/os/src/kernel/syscall/fs/rename_ops.rs
@@ -1,4 +1,13 @@
 use super::*;
+use alloc::string::String;
+
+fn split_rename_path(path: &str) -> Result<(String, String), FsError> {
+    if path == "/" {
+        return Ok((String::from("/"), String::from(".")));
+    }
+
+    split_parent_preserving_basename(path)
+}
 
 /// 重命名或移动文件/目录
 pub fn renameat2(
@@ -39,13 +48,13 @@ pub fn renameat2(
         return FsError::NotFound.to_errno();
     }
 
-    // 分割路径为 (父目录, 文件名)
-    let (old_dir_path, old_name) = match split_path(&old_path_str) {
+    // 分割路径为 (父目录, 文件名)，保留最后一级 "."/".."。
+    let (old_dir_path, old_name) = match split_rename_path(&old_path_str) {
         Ok(p) => p,
         Err(e) => return e.to_errno(),
     };
 
-    let (new_dir_path, new_name) = match split_path(&new_path_str) {
+    let (new_dir_path, new_name) = match split_rename_path(&new_path_str) {
         Ok(p) => p,
         Err(e) => return e.to_errno(),
     };
@@ -78,6 +87,16 @@ pub fn renameat2(
     };
     if new_parent_meta.inode_type != InodeType::Directory {
         return -(ENOTDIR as isize);
+    }
+
+    if is_special_basename(&old_name) {
+        return -(crate::uapi::errno::EBUSY as isize);
+    }
+    if is_special_basename(&new_name) {
+        if rename_flags.contains(RenameFlags::NOREPLACE) {
+            return -(EEXIST as isize);
+        }
+        return -(crate::uapi::errno::EBUSY as isize);
     }
 
     // 查找源文件(验证存在)

--- a/os/src/kernel/syscall/fs/rename_ops.rs
+++ b/os/src/kernel/syscall/fs/rename_ops.rs
@@ -35,6 +35,9 @@ pub fn renameat2(
         Ok(s) => s,
         Err(e) => return e.to_errno(),
     };
+    if old_path_str.is_empty() || new_path_str.is_empty() {
+        return FsError::NotFound.to_errno();
+    }
 
     // 分割路径为 (父目录, 文件名)
     let (old_dir_path, old_name) = match split_path(&old_path_str) {

--- a/os/src/kernel/syscall/fs/rename_ops.rs
+++ b/os/src/kernel/syscall/fs/rename_ops.rs
@@ -1,12 +1,33 @@
 use super::*;
 use alloc::string::String;
 
-fn split_rename_path(path: &str) -> Result<(String, String), FsError> {
-    if path == "/" {
-        return Ok((String::from("/"), String::from(".")));
+struct RenamePath {
+    parent: String,
+    name: String,
+    trailing_slash: bool,
+}
+
+fn split_rename_path(path: &str) -> Result<RenamePath, FsError> {
+    if path.bytes().all(|b| b == b'/') {
+        return Ok(RenamePath {
+            parent: String::from("/"),
+            name: String::from("."),
+            trailing_slash: false,
+        });
     }
 
-    split_parent_preserving_basename(path)
+    let trailing_slash = path.ends_with('/');
+    let path = if trailing_slash {
+        path.trim_end_matches('/')
+    } else {
+        path
+    };
+    let (parent, name) = split_parent_preserving_basename(path)?;
+    Ok(RenamePath {
+        parent,
+        name,
+        trailing_slash,
+    })
 }
 
 /// 重命名或移动文件/目录
@@ -49,24 +70,24 @@ pub fn renameat2(
     }
 
     // 分割路径为 (父目录, 文件名)，保留最后一级 "."/".."。
-    let (old_dir_path, old_name) = match split_rename_path(&old_path_str) {
+    let old_path = match split_rename_path(&old_path_str) {
         Ok(p) => p,
         Err(e) => return e.to_errno(),
     };
 
-    let (new_dir_path, new_name) = match split_rename_path(&new_path_str) {
+    let new_path = match split_rename_path(&new_path_str) {
         Ok(p) => p,
         Err(e) => return e.to_errno(),
     };
 
     // 查找父目录
-    let old_parent = match resolve_at_path(olddirfd, &old_dir_path) {
+    let old_parent = match resolve_at_path(olddirfd, &old_path.parent) {
         Ok(Some(d)) => d,
         Ok(None) => return -(ENOENT as isize),
         Err(e) => return e.to_errno(),
     };
 
-    let new_parent = match resolve_at_path(newdirfd, &new_dir_path) {
+    let new_parent = match resolve_at_path(newdirfd, &new_path.parent) {
         Ok(Some(d)) => d,
         Ok(None) => return -(ENOENT as isize),
         Err(e) => return e.to_errno(),
@@ -89,19 +110,28 @@ pub fn renameat2(
         return -(ENOTDIR as isize);
     }
 
-    if is_special_basename(&old_name) {
+    if is_special_basename(&old_path.name) {
         return -(crate::uapi::errno::EBUSY as isize);
     }
-    if is_special_basename(&new_name) {
+    if is_special_basename(&new_path.name) {
         if rename_flags.contains(RenameFlags::NOREPLACE) {
             return -(EEXIST as isize);
         }
         return -(crate::uapi::errno::EBUSY as isize);
     }
 
+    let old_requires_dir = old_path.trailing_slash;
+    let new_requires_dir = new_path.trailing_slash;
+    let old_name = old_path.name;
+    let new_name = new_path.name;
+
     // 查找源文件(验证存在)
-    let _old_inode = match old_parent.inode.lookup(&old_name) {
+    let old_inode = match old_parent.inode.lookup(&old_name) {
         Ok(inode) => inode,
+        Err(e) => return e.to_errno(),
+    };
+    let old_meta = match old_inode.metadata() {
+        Ok(meta) => meta,
         Err(e) => return e.to_errno(),
     };
 
@@ -130,7 +160,7 @@ pub fn renameat2(
         );
 
         // 验证目标文件存在
-        let _new_inode = match new_parent.inode.lookup(&new_name) {
+        let new_inode = match new_parent.inode.lookup(&new_name) {
             Ok(inode) => inode,
             Err(e) => {
                 crate::pr_err!(
@@ -141,6 +171,16 @@ pub fn renameat2(
                 return -(ENOENT as isize); // EXCHANGE 要求目标必须存在
             }
         };
+        let new_meta = match new_inode.metadata() {
+            Ok(meta) => meta,
+            Err(e) => return e.to_errno(),
+        };
+        if old_requires_dir && old_meta.inode_type != InodeType::Directory {
+            return -(ENOTDIR as isize);
+        }
+        if new_requires_dir && new_meta.inode_type != InodeType::Directory {
+            return -(ENOTDIR as isize);
+        }
 
         // 生成临时文件名(使用时间戳或特殊前缀避免冲突)
         let temp_name = alloc::format!(".rename_temp_{}_{}", old_name, new_name);
@@ -315,6 +355,9 @@ pub fn renameat2(
         if new_parent.inode.lookup(&new_name).is_ok() {
             return -(EEXIST as isize);
         }
+        if (old_requires_dir || new_requires_dir) && old_meta.inode_type != InodeType::Directory {
+            return -(ENOTDIR as isize);
+        }
 
         // 执行重命名
         if let Err(e) = old_parent
@@ -330,6 +373,24 @@ pub fn renameat2(
         // WHITEOUT 暂不支持(需要 Union FS 支持)
         return FsError::NotSupported.to_errno();
     } else {
+        if old_requires_dir && old_meta.inode_type != InodeType::Directory {
+            return -(ENOTDIR as isize);
+        }
+        if new_requires_dir {
+            if old_meta.inode_type != InodeType::Directory {
+                return -(ENOTDIR as isize);
+            }
+            if let Ok(new_inode) = new_parent.inode.lookup(&new_name) {
+                let new_meta = match new_inode.metadata() {
+                    Ok(meta) => meta,
+                    Err(e) => return e.to_errno(),
+                };
+                if new_meta.inode_type != InodeType::Directory {
+                    return -(ENOTDIR as isize);
+                }
+            }
+        }
+
         // 普通重命名/移动(允许覆盖目标)
         if let Err(e) = old_parent
             .inode

--- a/os/src/kernel/syscall/fs/stat_ops.rs
+++ b/os/src/kernel/syscall/fs/stat_ops.rs
@@ -420,17 +420,42 @@ pub fn utimensat(dirfd: i32, pathname: *const c_char, times: *const TimeSpec, fl
         Err(e) => return e.to_errno(),
     };
 
-    // 解析标志
-    let at_flags = match AtFlags::from_bits(flags) {
-        Some(f) => f,
-        None => return -(EINVAL as isize),
-    };
+    const UTIMENSAT_ALLOWED_FLAGS: u32 =
+        AtFlags::SYMLINK_NOFOLLOW.bits() | AtFlags::EMPTY_PATH.bits();
+    if flags & !UTIMENSAT_ALLOWED_FLAGS != 0 {
+        return -(EINVAL as isize);
+    }
+
+    let at_flags = AtFlags::from_bits_retain(flags);
 
     // 查找文件
-    let follow_symlink = !at_flags.contains(AtFlags::SYMLINK_NOFOLLOW);
-    let dentry = match resolve_at_path_with_flags(dirfd, &path_str, follow_symlink) {
-        Ok(d) => d,
-        Err(e) => return e.to_errno(),
+    let dentry = if path_str.is_empty() {
+        if !at_flags.contains(AtFlags::EMPTY_PATH) {
+            return FsError::NotFound.to_errno();
+        }
+
+        if dirfd == AT_FDCWD {
+            match current_task().lock().fs.lock().cwd.clone() {
+                Some(dentry) => dentry,
+                None => return FsError::IoError.to_errno(),
+            }
+        } else {
+            let task = current_task();
+            let file = match task.lock().fd_table.get(dirfd as usize) {
+                Ok(file) => file,
+                Err(e) => return e.to_errno(),
+            };
+            match file.dentry() {
+                Ok(dentry) => dentry,
+                Err(e) => return e.to_errno(),
+            }
+        }
+    } else {
+        let follow_symlink = !at_flags.contains(AtFlags::SYMLINK_NOFOLLOW);
+        match resolve_at_path_with_flags(dirfd, &path_str, follow_symlink) {
+            Ok(d) => d,
+            Err(e) => return e.to_errno(),
+        }
     };
 
     // 解析时间参数

--- a/os/src/kernel/syscall/fs/stat_ops.rs
+++ b/os/src/kernel/syscall/fs/stat_ops.rs
@@ -219,6 +219,9 @@ pub fn faccessat(dirfd: i32, pathname: *const c_char, mode: i32, flags: u32) -> 
         Ok(s) => s,
         Err(e) => return e.to_errno(),
     };
+    if path_str.is_empty() {
+        return FsError::NotFound.to_errno();
+    }
 
     if mode & !(R_OK | W_OK | X_OK) != 0 {
         return -(EINVAL as isize);

--- a/os/src/kernel/syscall/fs/stat_ops.rs
+++ b/os/src/kernel/syscall/fs/stat_ops.rs
@@ -303,6 +303,9 @@ pub fn readlinkat(dirfd: i32, pathname: *const c_char, buf: *mut u8, bufsiz: usi
         Ok(s) => s,
         Err(e) => return e.to_errno(),
     };
+    if path_str.is_empty() {
+        return FsError::NotFound.to_errno();
+    }
 
     // 查找符号链接（不跟随最后一级的符号链接）
     let dentry = match resolve_at_path_with_flags(dirfd, &path_str, false) {

--- a/os/src/kernel/syscall/fs/stat_ops.rs
+++ b/os/src/kernel/syscall/fs/stat_ops.rs
@@ -220,11 +220,16 @@ pub fn faccessat(dirfd: i32, pathname: *const c_char, mode: i32, flags: u32) -> 
         Err(e) => return e.to_errno(),
     };
 
-    // 解析标志
-    let at_flags = match AtFlags::from_bits(flags) {
-        Some(f) => f,
-        None => return -(EINVAL as isize),
-    };
+    if mode & !(R_OK | W_OK | X_OK) != 0 {
+        return -(EINVAL as isize);
+    }
+
+    const FACCESSAT_ALLOWED_FLAGS: u32 = AtFlags::SYMLINK_NOFOLLOW.bits() | AtFlags::EACCESS.bits();
+    if flags & !FACCESSAT_ALLOWED_FLAGS != 0 {
+        return -(EINVAL as isize);
+    }
+
+    let at_flags = AtFlags::from_bits_retain(flags);
 
     // 查找文件
     let follow_symlink = !at_flags.contains(AtFlags::SYMLINK_NOFOLLOW);

--- a/os/src/kernel/syscall/fs/stat_ops.rs
+++ b/os/src/kernel/syscall/fs/stat_ops.rs
@@ -1,5 +1,36 @@
 use super::*;
 
+fn metadata_at(
+    dirfd: i32,
+    path: &str,
+    at_flags: AtFlags,
+) -> Result<crate::vfs::InodeMetadata, FsError> {
+    if path.is_empty() {
+        if !at_flags.contains(AtFlags::EMPTY_PATH) {
+            return Err(FsError::NotFound);
+        }
+
+        if dirfd == AT_FDCWD {
+            let cwd = current_task()
+                .lock()
+                .fs
+                .lock()
+                .cwd
+                .clone()
+                .ok_or(FsError::IoError)?;
+            return cwd.inode.metadata();
+        }
+
+        let task = current_task();
+        let file = task.lock().fd_table.get(dirfd as usize)?;
+        return file.metadata();
+    }
+
+    let follow_symlink = !at_flags.contains(AtFlags::SYMLINK_NOFOLLOW);
+    let dentry = resolve_at_path_with_flags(dirfd, path, follow_symlink)?;
+    dentry.inode.metadata()
+}
+
 pub fn fstat(fd: usize, statbuf: *mut Stat) -> isize {
     // 检查指针有效性
     if statbuf.is_null() {
@@ -316,30 +347,16 @@ pub fn newfstatat(dirfd: i32, pathname: *const c_char, statbuf: *mut Stat, flags
         Err(e) => return e.to_errno(),
     };
 
-    // 解析标志
-    let at_flags = match AtFlags::from_bits(flags) {
-        Some(f) => f,
-        None => return -(EINVAL as isize),
-    };
-
-    // 处理 AT_EMPTY_PATH 标志
-    if path_str.is_empty() && at_flags.contains(AtFlags::EMPTY_PATH) {
-        if dirfd == AT_FDCWD {
-            return -(EINVAL as isize);
-        }
-        // 对 dirfd 执行 fstat
-        return fstat(dirfd as usize, statbuf);
+    const FSTATAT_ALLOWED_FLAGS: u32 =
+        AtFlags::SYMLINK_NOFOLLOW.bits() | AtFlags::EMPTY_PATH.bits();
+    if flags & !FSTATAT_ALLOWED_FLAGS != 0 {
+        return -(EINVAL as isize);
     }
 
-    // 查找文件
-    let follow_symlink = !at_flags.contains(AtFlags::SYMLINK_NOFOLLOW);
-    let dentry = match resolve_at_path_with_flags(dirfd, &path_str, follow_symlink) {
-        Ok(d) => d,
-        Err(e) => return e.to_errno(),
-    };
+    let at_flags = AtFlags::from_bits_retain(flags);
 
     // 获取文件元数据
-    let metadata = match dentry.inode.metadata() {
+    let metadata = match metadata_at(dirfd, &path_str, at_flags) {
         Ok(m) => m,
         Err(e) => return e.to_errno(),
     };
@@ -370,37 +387,18 @@ pub fn statx(
         Err(e) => return e.to_errno(),
     };
 
-    let at_flags = AtFlags::from_bits_truncate(flags);
-
-    // 处理 AT_EMPTY_PATH 标志：pathname 为空时，对 dirfd 指向的文件执行 statx
-    if path_str.is_empty() && at_flags.contains(AtFlags::EMPTY_PATH) {
-        if dirfd == AT_FDCWD {
-            return -(EINVAL as isize);
-        }
-
-        let task = current_task();
-        let file = match task.lock().fd_table.get(dirfd as usize) {
-            Ok(f) => f,
-            Err(e) => return e.to_errno(),
-        };
-        let metadata = match file.metadata() {
-            Ok(m) => m,
-            Err(e) => return e.to_errno(),
-        };
-
-        let stx = crate::vfs::Statx::from_metadata(&metadata);
-        unsafe { write_to_user(statxbuf, stx) };
-        return 0;
+    const STATX_SYNC_TYPE: u32 = 0x6000;
+    const STATX_ALLOWED_FLAGS: u32 = AtFlags::SYMLINK_NOFOLLOW.bits()
+        | AtFlags::EMPTY_PATH.bits()
+        | AtFlags::NO_AUTOMOUNT.bits()
+        | STATX_SYNC_TYPE;
+    if flags & !STATX_ALLOWED_FLAGS != 0 {
+        return -(EINVAL as isize);
     }
 
-    // 查找文件
-    let follow_symlink = !at_flags.contains(AtFlags::SYMLINK_NOFOLLOW);
-    let dentry = match resolve_at_path_with_flags(dirfd, &path_str, follow_symlink) {
-        Ok(d) => d,
-        Err(e) => return e.to_errno(),
-    };
+    let at_flags = AtFlags::from_bits_retain(flags);
 
-    let metadata = match dentry.inode.metadata() {
+    let metadata = match metadata_at(dirfd, &path_str, at_flags) {
         Ok(m) => m,
         Err(e) => return e.to_errno(),
     };

--- a/os/src/kernel/syscall/io.rs
+++ b/os/src/kernel/syscall/io.rs
@@ -50,10 +50,15 @@ fn copy_user_array<T: Copy>(
 
 fn should_retry_would_block(file: &Arc<dyn File>) -> bool {
     use crate::net::socket::SocketFile;
+    use crate::net::unix_socket::UnixSocketFile;
     use crate::uapi::fcntl::OpenFlags;
     use crate::vfs::PipeFile;
 
     if let Some(socket_file) = file.as_any().downcast_ref::<SocketFile>() {
+        return !socket_file.flags().contains(OpenFlags::O_NONBLOCK);
+    }
+
+    if let Some(socket_file) = file.as_any().downcast_ref::<UnixSocketFile>() {
         return !socket_file.flags().contains(OpenFlags::O_NONBLOCK);
     }
 

--- a/os/src/kernel/syscall/io.rs
+++ b/os/src/kernel/syscall/io.rs
@@ -10,6 +10,7 @@ use crate::util::user_buffer::{
     read_from_user, validate_user_ptr, validate_user_ptr_mut, write_to_user,
 };
 use crate::vfs::File;
+use alloc::sync::Arc;
 
 fn empty_iovec() -> IoVec {
     IoVec {
@@ -47,6 +48,37 @@ fn copy_user_array<T: Copy>(
     Ok(buf)
 }
 
+fn should_retry_would_block(file: &Arc<dyn File>) -> bool {
+    use crate::net::socket::SocketFile;
+    use crate::uapi::fcntl::OpenFlags;
+    use crate::vfs::PipeFile;
+
+    if let Some(socket_file) = file.as_any().downcast_ref::<SocketFile>() {
+        return !socket_file.flags().contains(OpenFlags::O_NONBLOCK);
+    }
+
+    if let Some(pipe_file) = file.as_any().downcast_ref::<PipeFile>() {
+        return !pipe_file.flags().contains(OpenFlags::O_NONBLOCK);
+    }
+
+    false
+}
+
+fn wait_for_would_block(file: Arc<dyn File>, task: crate::kernel::SharedTask) -> Result<(), isize> {
+    if file.as_any().is::<crate::net::socket::SocketFile>() {
+        crate::net::socket::poll_network_and_dispatch();
+    }
+
+    drop(file);
+    crate::kernel::yield_task();
+
+    if crate::ipc::signal_interrupts_syscall(&task) {
+        return Err(-(crate::uapi::errno::EINTR as isize));
+    }
+
+    Ok(())
+}
+
 /// 向文件描述符写入数据
 pub fn write(fd: usize, buf: *const u8, count: usize) -> isize {
     loop {
@@ -67,16 +99,10 @@ pub fn write(fd: usize, buf: *const u8, count: usize) -> isize {
         };
 
         if result == -11 {
-            use crate::net::socket::SocketFile;
-            if let Some(socket_file) = file.as_any().downcast_ref::<SocketFile>()
-                && !socket_file
-                    .flags()
-                    .contains(crate::uapi::fcntl::OpenFlags::O_NONBLOCK)
-            {
-                drop(file);
-                drop(task);
-                crate::net::socket::poll_network_and_dispatch();
-                crate::kernel::yield_task();
+            if should_retry_would_block(&file) {
+                if let Err(e) = wait_for_would_block(file, task) {
+                    return e;
+                }
                 continue;
             }
         }
@@ -111,16 +137,10 @@ pub fn read(fd: usize, buf: *mut u8, count: usize) -> isize {
         };
 
         if result == -11 {
-            use crate::net::socket::SocketFile;
-            if let Some(socket_file) = file.as_any().downcast_ref::<SocketFile>()
-                && !socket_file
-                    .flags()
-                    .contains(crate::uapi::fcntl::OpenFlags::O_NONBLOCK)
-            {
-                drop(file);
-                drop(task);
-                crate::net::socket::poll_network_and_dispatch();
-                crate::kernel::yield_task();
+            if should_retry_would_block(&file) {
+                if let Err(e) = wait_for_would_block(file, task) {
+                    return e;
+                }
                 continue;
             }
         }

--- a/os/src/kernel/syscall/mod.rs
+++ b/os/src/kernel/syscall/mod.rs
@@ -224,6 +224,7 @@ impl_syscall!(sys_sysinfo, sysinfo, (*mut SysInfo));
 
 // 网络 (Networking/Sockets)
 impl_syscall!(sys_socket, socket, (i32, i32, i32));
+impl_syscall!(sys_socketpair, socketpair, (i32, i32, i32, *mut i32));
 impl_syscall!(sys_bind, bind, (i32, *const u8, u32));
 impl_syscall!(sys_listen, listen, (i32, i32));
 impl_syscall!(sys_accept, accept, (i32, *mut u8, *mut u32));

--- a/os/src/kernel/syscall/mod.rs
+++ b/os/src/kernel/syscall/mod.rs
@@ -69,6 +69,11 @@ impl_syscall!(
     symlinkat,
     (*const c_char, i32, *const c_char)
 );
+impl_syscall!(
+    sys_linkat,
+    linkat,
+    (i32, *const c_char, i32, *const c_char, u32)
+);
 
 // 挂载/文件系统信息 (Mount/Filesystem Info)
 impl_syscall!(sys_statfs, statfs, (*const c_char, *mut LinuxStatFs));

--- a/os/src/kernel/syscall/network/addr_ops.rs
+++ b/os/src/kernel/syscall/network/addr_ops.rs
@@ -51,12 +51,36 @@ pub fn sendto(
         return send(sockfd, buf, len, 0);
     }
 
+    let task = current_task();
+    let file = match task.lock().fd_table.get(sockfd as usize) {
+        Ok(f) => f,
+        Err(_) => return -9, // EBADF
+    };
+    if let Some(unix_socket) = file.as_any().downcast_ref::<UnixSocketFile>() {
+        let unix_addr = match parse_sockaddr_un(dest_addr, addrlen) {
+            Ok(addr) => addr,
+            Err(e) => return e,
+        };
+        let mut kernel_buf = alloc::vec![0u8; len];
+        unsafe {
+            crate::arch::ArchImpl::copy_from_user(
+                crate::arch::address::UA::from_usize(buf as usize),
+                kernel_buf.as_mut_ptr(),
+                len,
+            )
+            .ok();
+        }
+        return match unix_socket.send_to(&kernel_buf, unix_addr) {
+            Ok(n) => n as isize,
+            Err(e) => e.to_errno(),
+        };
+    }
+
     let endpoint = match parse_sockaddr_in(dest_addr, addrlen) {
         Ok(e) => e,
         Err(e) => return e.to_errno(),
     };
 
-    let task = current_task();
     let tid = task.lock().tid as usize;
 
     let handle = match get_socket_handle(tid, sockfd as usize) {
@@ -185,6 +209,16 @@ pub fn recvfrom(
                         }
                         continue;
                     }
+                    if let Some(unix_socket) = file.as_any().downcast_ref::<UnixSocketFile>()
+                        && !unix_socket
+                            .flags()
+                            .contains(crate::uapi::fcntl::OpenFlags::O_NONBLOCK)
+                    {
+                        if let Err(e) = wait_unix_would_block(file, task) {
+                            return e;
+                        }
+                        continue;
+                    }
                 }
                 return e.to_errno();
             }
@@ -206,15 +240,19 @@ pub fn shutdown(sockfd: i32, how: i32) -> isize {
     let task_lock = task.lock();
     let tid = task_lock.tid as usize;
 
+    let file = match task_lock.fd_table.get(sockfd as usize) {
+        Ok(f) => f,
+        Err(_) => return -9, // EBADF
+    };
+    if let Some(unix_socket) = file.as_any().downcast_ref::<UnixSocketFile>() {
+        return unix_socket.shutdown(how);
+    }
+
     let handle = match get_socket_handle(tid, sockfd as usize) {
         Some(h) => h,
         None => return -88, // ENOTSOCK
     };
 
-    let file = match task_lock.fd_table.get(sockfd as usize) {
-        Ok(f) => f,
-        Err(_) => return -9, // EBADF
-    };
     drop(task_lock);
 
     use crate::net::socket::{socket_shutdown_read, socket_shutdown_write};
@@ -247,13 +285,20 @@ pub fn getsockname(sockfd: i32, addr: *mut u8, addrlen: *mut u32) -> isize {
     let task_lock = task.lock();
     let tid = task_lock.tid as usize;
 
-    let handle = match get_socket_handle(tid, sockfd as usize) {
-        Some(h) => h,
-        None => return -88, // ENOTSOCK
-    };
     let file = match task_lock.fd_table.get(sockfd as usize) {
         Ok(f) => f,
         Err(_) => return -9, // EBADF
+    };
+    if let Some(unix_socket) = file.as_any().downcast_ref::<UnixSocketFile>() {
+        return match write_sockaddr_un(addr, addrlen, unix_socket.local_addr()) {
+            Ok(()) => 0,
+            Err(e) => e,
+        };
+    }
+
+    let handle = match get_socket_handle(tid, sockfd as usize) {
+        Some(h) => h,
+        None => return -88, // ENOTSOCK
     };
     drop(task_lock);
 
@@ -280,6 +325,20 @@ pub fn getsockname(sockfd: i32, addr: *mut u8, addrlen: *mut u32) -> isize {
 pub fn getpeername(sockfd: i32, addr: *mut u8, addrlen: *mut u32) -> isize {
     let task = current_task();
     let tid = task.lock().tid as usize;
+
+    let file = match task.lock().fd_table.get(sockfd as usize) {
+        Ok(f) => f,
+        Err(_) => return -9, // EBADF
+    };
+    if let Some(unix_socket) = file.as_any().downcast_ref::<UnixSocketFile>() {
+        return match unix_socket.peer_addr() {
+            Some(peer) => match write_sockaddr_un(addr, addrlen, Some(peer)) {
+                Ok(()) => 0,
+                Err(e) => e,
+            },
+            None => -107, // ENOTCONN
+        };
+    }
 
     let handle = match get_socket_handle(tid, sockfd as usize) {
         Some(h) => h,

--- a/os/src/kernel/syscall/network/connection_ops.rs
+++ b/os/src/kernel/syscall/network/connection_ops.rs
@@ -2,6 +2,20 @@ use super::*;
 
 /// 连接到远程地址
 pub fn connect(sockfd: i32, addr: *const u8, addrlen: u32) -> isize {
+    let task = current_task();
+    let task_lock = task.lock();
+    let file = match task_lock.fd_table.get(sockfd as usize) {
+        Ok(f) => f,
+        Err(_) => return -9, // EBADF
+    };
+    if let Some(unix_socket) = file.as_any().downcast_ref::<UnixSocketFile>() {
+        let unix_addr = match parse_sockaddr_un(addr, addrlen) {
+            Ok(addr) => addr,
+            Err(e) => return e,
+        };
+        return unix_socket.connect(unix_addr);
+    }
+
     let endpoint = match parse_sockaddr_in(addr, addrlen) {
         Ok(e) => {
             pr_debug!("connect: sockfd={}, endpoint={}", sockfd, e);
@@ -10,8 +24,6 @@ pub fn connect(sockfd: i32, addr: *const u8, addrlen: u32) -> isize {
         Err(e) => return e.to_errno(),
     };
 
-    let task = current_task();
-    let task_lock = task.lock();
     let tid = task_lock.tid as usize;
 
     let handle = match get_socket_handle(tid, sockfd as usize) {
@@ -19,10 +31,6 @@ pub fn connect(sockfd: i32, addr: *const u8, addrlen: u32) -> isize {
         None => return -88, // ENOTSOCK
     };
 
-    let file = match task_lock.fd_table.get(sockfd as usize) {
-        Ok(f) => f,
-        Err(_) => return -9, // EBADF
-    };
     drop(task_lock);
 
     use crate::net::socket::set_socket_remote_endpoint;
@@ -245,17 +253,26 @@ pub fn send(sockfd: i32, buf: *const u8, len: usize, _flags: i32) -> isize {
             }
             Err(e) => {
                 pr_debug!("send: sockfd={}, len={} -> error={:?}", sockfd, len, e);
-                if e == crate::vfs::FsError::WouldBlock
-                    && let Some(socket_file) = file.as_any().downcast_ref::<SocketFile>()
-                    && !socket_file.flags().contains(OpenFlags::O_NONBLOCK)
-                {
-                    drop(file);
-                    crate::net::socket::poll_network_and_dispatch();
-                    crate::kernel::yield_task();
-                    if crate::ipc::signal_interrupts_syscall(&task) {
-                        return -(crate::uapi::errno::EINTR as isize);
+                if e == crate::vfs::FsError::WouldBlock {
+                    if let Some(socket_file) = file.as_any().downcast_ref::<SocketFile>()
+                        && !socket_file.flags().contains(OpenFlags::O_NONBLOCK)
+                    {
+                        drop(file);
+                        crate::net::socket::poll_network_and_dispatch();
+                        crate::kernel::yield_task();
+                        if crate::ipc::signal_interrupts_syscall(&task) {
+                            return -(crate::uapi::errno::EINTR as isize);
+                        }
+                        continue;
                     }
-                    continue;
+                    if let Some(unix_socket) = file.as_any().downcast_ref::<UnixSocketFile>()
+                        && !unix_socket.flags().contains(OpenFlags::O_NONBLOCK)
+                    {
+                        if let Err(e) = wait_unix_would_block(file, task) {
+                            return e;
+                        }
+                        continue;
+                    }
                 }
                 return e.to_errno();
             }
@@ -309,17 +326,26 @@ pub fn recv(sockfd: i32, buf: *mut u8, len: usize, _flags: i32) -> isize {
             }
             Err(e) => {
                 pr_debug!("recv: sockfd={}, len={} -> error={:?}", sockfd, len, e);
-                if e == crate::vfs::FsError::WouldBlock
-                    && let Some(socket_file) = file.as_any().downcast_ref::<SocketFile>()
-                    && !socket_file.flags().contains(OpenFlags::O_NONBLOCK)
-                {
-                    drop(file);
-                    crate::net::socket::poll_network_and_dispatch();
-                    crate::kernel::yield_task();
-                    if crate::ipc::signal_interrupts_syscall(&task) {
-                        return -(crate::uapi::errno::EINTR as isize);
+                if e == crate::vfs::FsError::WouldBlock {
+                    if let Some(socket_file) = file.as_any().downcast_ref::<SocketFile>()
+                        && !socket_file.flags().contains(OpenFlags::O_NONBLOCK)
+                    {
+                        drop(file);
+                        crate::net::socket::poll_network_and_dispatch();
+                        crate::kernel::yield_task();
+                        if crate::ipc::signal_interrupts_syscall(&task) {
+                            return -(crate::uapi::errno::EINTR as isize);
+                        }
+                        continue;
                     }
-                    continue;
+                    if let Some(unix_socket) = file.as_any().downcast_ref::<UnixSocketFile>()
+                        && !unix_socket.flags().contains(OpenFlags::O_NONBLOCK)
+                    {
+                        if let Err(e) = wait_unix_would_block(file, task) {
+                            return e;
+                        }
+                        continue;
+                    }
                 }
                 return e.to_errno();
             }

--- a/os/src/kernel/syscall/network/mod.rs
+++ b/os/src/kernel/syscall/network/mod.rs
@@ -107,11 +107,15 @@ use crate::{
             parse_sockaddr_in, register_socket_fd, unregister_socket_fd, write_sockaddr_in,
         },
         stack::{TcpConnectionState, TcpListenState, network_stack},
+        unix_socket::{
+            UnixSocketFile, create_unix_socket, create_unix_socket_pair, parse_sockaddr_un,
+            wait_unix_would_block, write_sockaddr_un, write_socketpair_fds,
+        },
     },
     pr_debug, pr_info, println,
     uapi::{
         fcntl::{FdFlags, OpenFlags},
-        socket::{SOCK_CLOEXEC, SOCK_DGRAM, SOCK_NONBLOCK, SOCK_STREAM, SOCK_TYPE_MASK},
+        socket::{AF_UNIX, SOCK_CLOEXEC, SOCK_DGRAM, SOCK_NONBLOCK, SOCK_STREAM, SOCK_TYPE_MASK},
     },
 };
 use alloc::sync::Arc;

--- a/os/src/kernel/syscall/network/socket_ops.rs
+++ b/os/src/kernel/syscall/network/socket_ops.rs
@@ -2,10 +2,6 @@ use super::*;
 
 /// 创建套接字
 pub fn socket(domain: i32, socket_type: i32, _protocol: i32) -> isize {
-    if domain != 2 {
-        return -97;
-    } // EAFNOSUPPORT
-
     let base_type = socket_type & SOCK_TYPE_MASK;
     let extra_flags = socket_type & !SOCK_TYPE_MASK;
     let supported_flags = SOCK_NONBLOCK | SOCK_CLOEXEC;
@@ -23,6 +19,23 @@ pub fn socket(domain: i32, socket_type: i32, _protocol: i32) -> isize {
     } else {
         FdFlags::empty()
     };
+
+    if domain == AF_UNIX {
+        let socket_file = match create_unix_socket(base_type, open_flags) {
+            Ok(file) => file,
+            Err(e) => return e,
+        };
+        let task = current_task();
+        let task_lock = task.lock();
+        return match task_lock.fd_table.alloc_with_flags(socket_file, fd_flags) {
+            Ok(fd) => fd as isize,
+            Err(e) => e.to_errno(),
+        };
+    }
+
+    if domain != 2 {
+        return -97;
+    } // EAFNOSUPPORT
 
     let handle = match base_type {
         SOCK_STREAM => match create_tcp_socket() {
@@ -62,15 +75,78 @@ pub fn socket(domain: i32, socket_type: i32, _protocol: i32) -> isize {
     }
 }
 
+/// 创建一对已连接的套接字
+pub fn socketpair(domain: i32, socket_type: i32, _protocol: i32, sv: *mut i32) -> isize {
+    if domain != AF_UNIX {
+        return -97; // EAFNOSUPPORT
+    }
+
+    let base_type = socket_type & SOCK_TYPE_MASK;
+    let extra_flags = socket_type & !SOCK_TYPE_MASK;
+    let supported_flags = SOCK_NONBLOCK | SOCK_CLOEXEC;
+    if extra_flags & !supported_flags != 0 {
+        return -22; // EINVAL
+    }
+
+    let mut open_flags = OpenFlags::empty();
+    if extra_flags & SOCK_NONBLOCK != 0 {
+        open_flags |= OpenFlags::O_NONBLOCK;
+    }
+    let fd_flags = if extra_flags & SOCK_CLOEXEC != 0 {
+        FdFlags::CLOEXEC
+    } else {
+        FdFlags::empty()
+    };
+
+    let (left, right) = match create_unix_socket_pair(base_type, open_flags) {
+        Ok(pair) => pair,
+        Err(e) => return e,
+    };
+
+    let task = current_task();
+    let task_lock = task.lock();
+    let left_fd = match task_lock.fd_table.alloc_with_flags(left, fd_flags) {
+        Ok(fd) => fd,
+        Err(e) => return e.to_errno(),
+    };
+    let right_fd = match task_lock.fd_table.alloc_with_flags(right, fd_flags) {
+        Ok(fd) => fd,
+        Err(e) => {
+            let _ = task_lock.fd_table.close(left_fd);
+            return e.to_errno();
+        }
+    };
+
+    if let Err(e) = write_socketpair_fds(sv, left_fd, right_fd) {
+        let _ = task_lock.fd_table.close(left_fd);
+        let _ = task_lock.fd_table.close(right_fd);
+        return e;
+    }
+
+    0
+}
+
 /// 绑定套接字
 pub fn bind(sockfd: i32, addr: *const u8, addrlen: u32) -> isize {
+    let task = current_task();
+    let task_lock = task.lock();
+    let file = match task_lock.fd_table.get(sockfd as usize) {
+        Ok(f) => f,
+        Err(_) => return -9, // EBADF
+    };
+    if let Some(unix_socket) = file.as_any().downcast_ref::<UnixSocketFile>() {
+        let unix_addr = match parse_sockaddr_un(addr, addrlen) {
+            Ok(addr) => addr,
+            Err(e) => return e,
+        };
+        return unix_socket.bind(unix_addr);
+    }
+
     let endpoint = match parse_sockaddr_in(addr, addrlen) {
         Ok(e) => e,
         Err(e) => return e.to_errno(),
     };
 
-    let task = current_task();
-    let task_lock = task.lock();
     let tid = task_lock.tid as usize;
 
     pr_debug!(
@@ -177,14 +253,17 @@ pub fn listen(sockfd: i32, backlog: i32) -> isize {
     let task_lock = task.lock();
     let tid = task_lock.tid as usize;
 
-    let handle = match get_socket_handle(tid, sockfd as usize) {
-        Some(h) => h,
-        None => return -88, // ENOTSOCK
-    };
-
     let file = match task_lock.fd_table.get(sockfd as usize) {
         Ok(f) => f,
         Err(_) => return -9, // EBADF
+    };
+    if let Some(unix_socket) = file.as_any().downcast_ref::<UnixSocketFile>() {
+        return unix_socket.listen(backlog);
+    }
+
+    let handle = match get_socket_handle(tid, sockfd as usize) {
+        Some(h) => h,
+        None => return -88, // ENOTSOCK
     };
     drop(task_lock);
 
@@ -278,6 +357,32 @@ pub fn accept(sockfd: i32, addr: *mut u8, addrlen: *mut u32) -> isize {
         Ok(f) => f,
         Err(_) => return -9, // EBADF
     };
+
+    if let Some(unix_socket) = file.as_any().downcast_ref::<UnixSocketFile>() {
+        let is_nonblock = unix_socket.flags().contains(OpenFlags::O_NONBLOCK);
+        loop {
+            match unix_socket.accept() {
+                Ok(conn) => {
+                    let peer_addr = conn.peer_addr();
+                    if let Err(e) = write_sockaddr_un(addr, addrlen, peer_addr) {
+                        return e;
+                    }
+                    return match task.lock().fd_table.alloc(conn) {
+                        Ok(fd) => fd as isize,
+                        Err(e) => e.to_errno(),
+                    };
+                }
+                Err(e) if e == -(crate::uapi::errno::EAGAIN as isize) && !is_nonblock => {
+                    crate::kernel::yield_task();
+                    if crate::ipc::signal_interrupts_syscall(&task) {
+                        return -(crate::uapi::errno::EINTR as isize);
+                    }
+                    continue;
+                }
+                Err(e) => return e,
+            }
+        }
+    }
 
     use crate::net::socket::SocketFile;
     let socket_file = match file.as_any().downcast_ref::<SocketFile>() {

--- a/os/src/kernel/syscall/network/sockopt_ops.rs
+++ b/os/src/kernel/syscall/network/sockopt_ops.rs
@@ -15,15 +15,42 @@ pub fn setsockopt(sockfd: i32, level: i32, optname: i32, optval: *const u8, optl
         Err(_) => return -(EBADF as isize),
     };
 
-    let socket_file = match file
+    enum SocketOptionTarget<'a> {
+        Inet(&'a crate::net::socket::SocketFile),
+        Unix(&'a crate::net::unix_socket::UnixSocketFile),
+    }
+
+    impl SocketOptionTarget<'_> {
+        fn get(&self) -> crate::uapi::socket::SocketOptions {
+            match self {
+                Self::Inet(socket) => socket.get_socket_options(),
+                Self::Unix(socket) => socket.get_socket_options(),
+            }
+        }
+
+        fn set(&self, options: crate::uapi::socket::SocketOptions) {
+            match self {
+                Self::Inet(socket) => socket.set_socket_options(options),
+                Self::Unix(socket) => socket.set_socket_options(options),
+            }
+        }
+    }
+
+    let target = if let Some(sf) = file
         .as_any()
         .downcast_ref::<crate::net::socket::SocketFile>()
     {
-        Some(sf) => sf,
-        None => return -(ENOTSOCK as isize),
+        SocketOptionTarget::Inet(sf)
+    } else if let Some(sf) = file
+        .as_any()
+        .downcast_ref::<crate::net::unix_socket::UnixSocketFile>()
+    {
+        SocketOptionTarget::Unix(sf)
+    } else {
+        return -(ENOTSOCK as isize);
     };
 
-    let mut opts = socket_file.get_socket_options();
+    let mut opts = target.get();
 
     match level {
         SOL_SOCKET => match optname {
@@ -37,6 +64,7 @@ pub fn setsockopt(sockfd: i32, level: i32, optname: i32, optval: *const u8, optl
             SO_RCVTIMEO_OLD | SO_SNDTIMEO_OLD => { /* Ignore timeout options */ }
             _ => return -(ENOPROTOOPT as isize),
         },
+        _ if matches!(target, SocketOptionTarget::Unix(_)) => return -(ENOPROTOOPT as isize),
         IPPROTO_IP => match optname {
             IP_TOS | IP_TTL | IP_PKTINFO | IP_MTU_DISCOVER | IP_RECVERR => { /* ignore */ }
             _ => return -(ENOPROTOOPT as isize),
@@ -52,7 +80,7 @@ pub fn setsockopt(sockfd: i32, level: i32, optname: i32, optval: *const u8, optl
         _ => return -(ENOPROTOOPT as isize),
     }
 
-    socket_file.set_socket_options(opts);
+    target.set(opts);
     0
 }
 
@@ -77,15 +105,28 @@ pub fn getsockopt(
         Err(_) => return -(EBADF as isize),
     };
 
-    let socket_file = match file
+    let opts = if let Some(sf) = file
         .as_any()
         .downcast_ref::<crate::net::socket::SocketFile>()
     {
-        Some(sf) => sf,
-        None => return -(ENOTSOCK as isize),
+        sf.get_socket_options()
+    } else if let Some(sf) = file
+        .as_any()
+        .downcast_ref::<crate::net::unix_socket::UnixSocketFile>()
+    {
+        sf.get_socket_options()
+    } else {
+        return -(ENOTSOCK as isize);
     };
 
-    let opts = socket_file.get_socket_options();
+    if file
+        .as_any()
+        .downcast_ref::<crate::net::unix_socket::UnixSocketFile>()
+        .is_some()
+        && level != SOL_SOCKET
+    {
+        return -(ENOPROTOOPT as isize);
+    };
 
     let available_len = read_from_user(optlen as *const u32) as usize;
     let mut written_len = 0usize;

--- a/os/src/kernel/syscall/numbers.rs
+++ b/os/src/kernel/syscall/numbers.rs
@@ -15,6 +15,7 @@ pub const SYS_MKNODAT: usize = 33;
 pub const SYS_MKDIRAT: usize = 34;
 pub const SYS_UNLINKAT: usize = 35;
 pub const SYS_SYMLINKAT: usize = 36;
+pub const SYS_LINKAT: usize = 37;
 pub const SYS_MOUNT: usize = 40;
 pub const SYS_UMOUNT2: usize = 39;
 pub const SYS_STATFS: usize = 43;

--- a/os/src/kernel/syscall/numbers.rs
+++ b/os/src/kernel/syscall/numbers.rs
@@ -118,6 +118,7 @@ pub const SYS_SYSINFO: usize = 179;
 
 // ---- 网络/Socket ----
 pub const SYS_SOCKET: usize = 198;
+pub const SYS_SOCKETPAIR: usize = 199;
 pub const SYS_BIND: usize = 200;
 pub const SYS_LISTEN: usize = 201;
 pub const SYS_ACCEPT: usize = 202;

--- a/os/src/kernel/syscall/util.rs
+++ b/os/src/kernel/syscall/util.rs
@@ -15,7 +15,7 @@ use crate::{
     uapi::{errno::EINVAL, log::SyslogAction},
     vfs::{
         DENTRY_CACHE, Dentry, File, FileMode, FsError, InodeType, OpenFlags, get_root_dentry,
-        impls::{BlockDeviceFile, CharDeviceFile, RegFile},
+        impls::{BlockDeviceFile, CharDeviceFile, PipeFile, RegFile},
         normalize_path, split_path, vfs_lookup_from,
     },
 };
@@ -494,8 +494,12 @@ pub fn create_file_from_dentry(
             // 块设备
             Arc::new(BlockDeviceFile::new(dentry, flags)?)
         }
-        InodeType::Socket | InodeType::Fifo => {
-            // FIFO（命名管道） 和 Unix 域套接字 暂不支持
+        InodeType::Fifo => {
+            // FIFO（命名管道）
+            Arc::new(PipeFile::open_fifo(dentry, flags)?)
+        }
+        InodeType::Socket => {
+            // Unix 域套接字节点的运行时语义由 socket 子系统处理。
             return Err(FsError::NotSupported);
         }
     };

--- a/os/src/kernel/syscall/util.rs
+++ b/os/src/kernel/syscall/util.rs
@@ -16,11 +16,15 @@ use crate::{
     vfs::{
         DENTRY_CACHE, Dentry, File, FileMode, FsError, InodeType, OpenFlags, get_root_dentry,
         impls::{BlockDeviceFile, CharDeviceFile, PipeFile, RegFile},
-        normalize_path, split_path, vfs_lookup_from,
+        normalize_path, vfs_lookup_from,
     },
 };
 
 const PATH_MAX: usize = 4096;
+
+pub fn is_special_basename(name: &str) -> bool {
+    name == "." || name == ".."
+}
 
 /// 从用户空间复制字符串到内核缓冲区
 fn copy_str_from_user(user_ptr: usize) -> Result<String, FsError> {
@@ -183,6 +187,38 @@ pub fn resolve_at_path_string(dirfd: i32, path: &str) -> Result<String, FsError>
     }
 }
 
+/// Split a path for syscalls that operate on a parent directory and a final name.
+///
+/// Unlike VFS `split_path`, this preserves a final `.` or `..` component so
+/// create/unlink style syscalls cannot accidentally operate on the normalized
+/// target instead.
+pub fn split_parent_preserving_basename(path: &str) -> Result<(String, String), FsError> {
+    if path.is_empty() {
+        return Err(FsError::NotFound);
+    }
+    if path.ends_with('/') && path.len() > 1 {
+        return Err(FsError::InvalidArgument);
+    }
+
+    if let Some(pos) = path.rfind('/') {
+        let name = String::from(&path[pos + 1..]);
+        if name.is_empty() {
+            return Err(FsError::InvalidArgument);
+        }
+
+        let parent = &path[..pos];
+        let parent = if parent.is_empty() {
+            String::from("/")
+        } else {
+            normalize_path(parent)
+        };
+
+        Ok((parent, name))
+    } else {
+        Ok((String::from("."), String::from(path)))
+    }
+}
+
 /// 在指定目录下创建一个新文件
 ///// # 参数
 /// - `dirfd`: 目录文件描述符，或 AT_FDCWD
@@ -190,7 +226,7 @@ pub fn resolve_at_path_string(dirfd: i32, path: &str) -> Result<String, FsError>
 /// - `mode`: 文件权限模式
 /// 返回新创建的文件的 Dentry
 pub fn create_file_at(dirfd: i32, path: &str, mode: u32) -> Result<Arc<Dentry>, FsError> {
-    let (dir_path, filename) = split_path(path)?;
+    let (dir_path, filename) = split_parent_preserving_basename(path)?;
     let parent_dentry = match resolve_at_path(dirfd, &dir_path)? {
         Some(d) => d,
         None => return Err(FsError::NotFound),
@@ -199,6 +235,9 @@ pub fn create_file_at(dirfd: i32, path: &str, mode: u32) -> Result<Arc<Dentry>, 
     let meta = parent_dentry.inode.metadata()?;
     if meta.inode_type != InodeType::Directory {
         return Err(FsError::NotDirectory);
+    }
+    if is_special_basename(&filename) {
+        return Err(FsError::AlreadyExists);
     }
 
     let file_mode = FileMode::from_bits_truncate(mode) | FileMode::S_IFREG;

--- a/os/src/net/mod.rs
+++ b/os/src/net/mod.rs
@@ -8,6 +8,7 @@ pub mod config;
 pub mod interface;
 pub mod socket;
 pub mod stack;
+pub mod unix_socket;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum NetworkError {

--- a/os/src/net/unix_socket.rs
+++ b/os/src/net/unix_socket.rs
@@ -1,0 +1,797 @@
+//! Minimal AF_UNIX socket implementation.
+//!
+//! This is an in-kernel IPC transport. It deliberately does not use smoltcp:
+//! AF_UNIX addresses are local paths/abstract names, not IP endpoints.
+
+use crate::{
+    arch::Arch,
+    sync::SpinLock,
+    uapi::{
+        errno::{EADDRINUSE, ECONNREFUSED, EINTR, EINVAL, EOPNOTSUPP},
+        fcntl::OpenFlags,
+        socket::{AF_UNIX, SOCK_DGRAM, SOCK_STREAM, SocketOptions},
+        time::TimeSpec,
+    },
+    util::user_buffer::{read_from_user, write_to_user},
+    vfs::{File, FileMode, FsError, InodeMetadata, InodeType, split_path, vfs_lookup},
+};
+use alloc::{
+    collections::{BTreeMap, VecDeque},
+    string::{String, ToString},
+    sync::{Arc, Weak},
+    vec,
+    vec::Vec,
+};
+
+const SOCKADDR_UN_PATH_OFFSET: usize = 2;
+const UNIX_PATH_MAX: usize = 108;
+const STREAM_BUFFER_CAPACITY: usize = 64 * 1024;
+const DGRAM_QUEUE_CAPACITY: usize = 128;
+const DGRAM_MAX_SIZE: usize = 8192;
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum UnixSocketAddr {
+    Path(String),
+    Abstract(Vec<u8>),
+}
+
+impl UnixSocketAddr {
+    fn path_bytes(&self) -> Vec<u8> {
+        match self {
+            Self::Path(path) => {
+                let mut bytes = path.as_bytes().to_vec();
+                bytes.push(0);
+                bytes
+            }
+            Self::Abstract(name) => {
+                let mut bytes = Vec::with_capacity(name.len() + 1);
+                bytes.push(0);
+                bytes.extend_from_slice(name);
+                bytes
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnixSocketKind {
+    Stream,
+    Datagram,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StreamSide {
+    A,
+    B,
+}
+
+#[derive(Debug)]
+struct UnixStreamConnection {
+    a_to_b: VecDeque<u8>,
+    b_to_a: VecDeque<u8>,
+    a_closed_read: bool,
+    a_closed_write: bool,
+    b_closed_read: bool,
+    b_closed_write: bool,
+}
+
+impl UnixStreamConnection {
+    fn new() -> Self {
+        Self {
+            a_to_b: VecDeque::new(),
+            b_to_a: VecDeque::new(),
+            a_closed_read: false,
+            a_closed_write: false,
+            b_closed_read: false,
+            b_closed_write: false,
+        }
+    }
+
+    fn inbound(&self, side: StreamSide) -> &VecDeque<u8> {
+        match side {
+            StreamSide::A => &self.b_to_a,
+            StreamSide::B => &self.a_to_b,
+        }
+    }
+
+    fn outbound(&self, side: StreamSide) -> &VecDeque<u8> {
+        match side {
+            StreamSide::A => &self.a_to_b,
+            StreamSide::B => &self.b_to_a,
+        }
+    }
+
+    fn outbound_mut(&mut self, side: StreamSide) -> &mut VecDeque<u8> {
+        match side {
+            StreamSide::A => &mut self.a_to_b,
+            StreamSide::B => &mut self.b_to_a,
+        }
+    }
+
+    fn local_read_closed(&self, side: StreamSide) -> bool {
+        match side {
+            StreamSide::A => self.a_closed_read,
+            StreamSide::B => self.b_closed_read,
+        }
+    }
+
+    fn local_write_closed(&self, side: StreamSide) -> bool {
+        match side {
+            StreamSide::A => self.a_closed_write,
+            StreamSide::B => self.b_closed_write,
+        }
+    }
+
+    fn peer_read_closed(&self, side: StreamSide) -> bool {
+        match side {
+            StreamSide::A => self.b_closed_read,
+            StreamSide::B => self.a_closed_read,
+        }
+    }
+
+    fn peer_write_closed(&self, side: StreamSide) -> bool {
+        match side {
+            StreamSide::A => self.b_closed_write,
+            StreamSide::B => self.a_closed_write,
+        }
+    }
+
+    fn close_read(&mut self, side: StreamSide) {
+        match side {
+            StreamSide::A => self.a_closed_read = true,
+            StreamSide::B => self.b_closed_read = true,
+        }
+    }
+
+    fn close_write(&mut self, side: StreamSide) {
+        match side {
+            StreamSide::A => self.a_closed_write = true,
+            StreamSide::B => self.b_closed_write = true,
+        }
+    }
+}
+
+#[derive(Clone)]
+struct UnixDatagram {
+    data: Vec<u8>,
+    source: Option<UnixSocketAddr>,
+}
+
+enum UnixSocketState {
+    Unconnected,
+    Listening {
+        backlog: usize,
+        pending: VecDeque<Arc<UnixSocketFile>>,
+    },
+    Connected {
+        conn: Arc<SpinLock<UnixStreamConnection>>,
+        side: StreamSide,
+    },
+}
+
+pub struct UnixSocketFile {
+    kind: UnixSocketKind,
+    self_ref: Weak<UnixSocketFile>,
+    flags: SpinLock<OpenFlags>,
+    options: SpinLock<SocketOptions>,
+    local_addr: SpinLock<Option<UnixSocketAddr>>,
+    peer_addr: SpinLock<Option<UnixSocketAddr>>,
+    registered_addr: SpinLock<Option<UnixSocketAddr>>,
+    state: SpinLock<UnixSocketState>,
+    dgram_queue: SpinLock<VecDeque<UnixDatagram>>,
+    dgram_peer: SpinLock<Option<Weak<UnixSocketFile>>>,
+    shutdown_read: SpinLock<bool>,
+    shutdown_write: SpinLock<bool>,
+}
+
+lazy_static::lazy_static! {
+    static ref UNIX_BINDINGS: SpinLock<BTreeMap<UnixSocketAddr, Weak<UnixSocketFile>>> =
+        SpinLock::new(BTreeMap::new());
+}
+
+pub fn create_unix_socket(
+    socket_type: i32,
+    flags: OpenFlags,
+) -> Result<Arc<UnixSocketFile>, isize> {
+    let kind = match socket_type {
+        SOCK_STREAM => UnixSocketKind::Stream,
+        SOCK_DGRAM => UnixSocketKind::Datagram,
+        _ => return Err(-(crate::uapi::errno::ESOCKTNOSUPPORT as isize)),
+    };
+    Ok(UnixSocketFile::new(kind, flags))
+}
+
+pub fn create_unix_socket_pair(
+    socket_type: i32,
+    flags: OpenFlags,
+) -> Result<(Arc<UnixSocketFile>, Arc<UnixSocketFile>), isize> {
+    match socket_type {
+        SOCK_STREAM => {
+            let conn = Arc::new(SpinLock::new(UnixStreamConnection::new()));
+            let left = UnixSocketFile::new_connected_stream(flags, conn.clone(), StreamSide::A);
+            let right = UnixSocketFile::new_connected_stream(flags, conn, StreamSide::B);
+            Ok((left, right))
+        }
+        SOCK_DGRAM => {
+            let left = UnixSocketFile::new(UnixSocketKind::Datagram, flags);
+            let right = UnixSocketFile::new(UnixSocketKind::Datagram, flags);
+            *left.dgram_peer.lock() = Some(Arc::downgrade(&right));
+            *right.dgram_peer.lock() = Some(Arc::downgrade(&left));
+            Ok((left, right))
+        }
+        _ => Err(-(crate::uapi::errno::ESOCKTNOSUPPORT as isize)),
+    }
+}
+
+pub fn parse_sockaddr_un(addr: *const u8, addrlen: u32) -> Result<UnixSocketAddr, isize> {
+    if addr.is_null() || (addrlen as usize) < SOCKADDR_UN_PATH_OFFSET {
+        return Err(-(EINVAL as isize));
+    }
+
+    let copy_len = (addrlen as usize).min(SOCKADDR_UN_PATH_OFFSET + UNIX_PATH_MAX);
+    let mut buf = [0u8; SOCKADDR_UN_PATH_OFFSET + UNIX_PATH_MAX];
+    unsafe {
+        crate::arch::ArchImpl::copy_from_user(
+            crate::arch::address::UA::from_usize(addr as usize),
+            buf.as_mut_ptr(),
+            copy_len,
+        )
+    }
+    .map_err(|_| -(crate::uapi::errno::EFAULT as isize))?;
+
+    let family = u16::from_ne_bytes([buf[0], buf[1]]);
+    if family != AF_UNIX as u16 {
+        return Err(-(EINVAL as isize));
+    }
+
+    let path_len = copy_len.saturating_sub(SOCKADDR_UN_PATH_OFFSET);
+    if path_len == 0 {
+        return Err(-(EINVAL as isize));
+    }
+
+    let path_bytes = &buf[SOCKADDR_UN_PATH_OFFSET..SOCKADDR_UN_PATH_OFFSET + path_len];
+    if path_bytes[0] == 0 {
+        return Ok(UnixSocketAddr::Abstract(path_bytes[1..].to_vec()));
+    }
+
+    let nul = path_bytes
+        .iter()
+        .position(|&b| b == 0)
+        .unwrap_or(path_bytes.len());
+    if nul == 0 {
+        return Err(-(EINVAL as isize));
+    }
+
+    let path = core::str::from_utf8(&path_bytes[..nul])
+        .map_err(|_| -(EINVAL as isize))?
+        .to_string();
+    Ok(UnixSocketAddr::Path(path))
+}
+
+pub fn write_sockaddr_un(
+    addr: *mut u8,
+    addrlen: *mut u32,
+    endpoint: Option<UnixSocketAddr>,
+) -> Result<(), isize> {
+    if addr.is_null() || addrlen.is_null() {
+        return Ok(());
+    }
+
+    let endpoint = match endpoint {
+        Some(endpoint) => endpoint,
+        None => {
+            write_to_user(addrlen, SOCKADDR_UN_PATH_OFFSET as u32);
+            return Ok(());
+        }
+    };
+
+    let user_len = read_from_user(addrlen as *const u32) as usize;
+    let mut buf = [0u8; SOCKADDR_UN_PATH_OFFSET + UNIX_PATH_MAX];
+    buf[0..2].copy_from_slice(&(AF_UNIX as u16).to_ne_bytes());
+    let path = endpoint.path_bytes();
+    let path_copy_len = path.len().min(UNIX_PATH_MAX);
+    buf[SOCKADDR_UN_PATH_OFFSET..SOCKADDR_UN_PATH_OFFSET + path_copy_len]
+        .copy_from_slice(&path[..path_copy_len]);
+
+    let total_len = SOCKADDR_UN_PATH_OFFSET + path_copy_len;
+    let copy_len = user_len.min(total_len);
+    unsafe {
+        crate::arch::ArchImpl::copy_to_user(
+            buf.as_ptr(),
+            crate::arch::address::UA::from_usize(addr as usize),
+            copy_len,
+        )
+    }
+    .map_err(|_| -(crate::uapi::errno::EFAULT as isize))?;
+    write_to_user(addrlen, total_len as u32);
+    Ok(())
+}
+
+impl UnixSocketFile {
+    fn new(kind: UnixSocketKind, flags: OpenFlags) -> Arc<Self> {
+        Arc::new_cyclic(|self_ref| Self {
+            kind,
+            self_ref: self_ref.clone(),
+            flags: SpinLock::new(flags),
+            options: SpinLock::new(SocketOptions::default()),
+            local_addr: SpinLock::new(None),
+            peer_addr: SpinLock::new(None),
+            registered_addr: SpinLock::new(None),
+            state: SpinLock::new(UnixSocketState::Unconnected),
+            dgram_queue: SpinLock::new(VecDeque::new()),
+            dgram_peer: SpinLock::new(None),
+            shutdown_read: SpinLock::new(false),
+            shutdown_write: SpinLock::new(false),
+        })
+    }
+
+    fn new_connected_stream(
+        flags: OpenFlags,
+        conn: Arc<SpinLock<UnixStreamConnection>>,
+        side: StreamSide,
+    ) -> Arc<Self> {
+        let socket = Self::new(UnixSocketKind::Stream, flags);
+        *socket.state.lock() = UnixSocketState::Connected { conn, side };
+        socket
+    }
+
+    pub fn get_socket_options(&self) -> SocketOptions {
+        *self.options.lock()
+    }
+
+    pub fn set_socket_options(&self, options: SocketOptions) {
+        *self.options.lock() = options;
+    }
+
+    pub fn bind(&self, addr: UnixSocketAddr) -> isize {
+        if self.local_addr.lock().is_some() {
+            return -(EINVAL as isize);
+        }
+
+        let self_arc = match self.self_ref.upgrade() {
+            Some(socket) => socket,
+            None => return -(EINVAL as isize),
+        };
+
+        if let UnixSocketAddr::Path(path) = &addr
+            && let Err(errno) = create_socket_node(path)
+        {
+            return errno;
+        }
+
+        let mut bindings = UNIX_BINDINGS.lock();
+        if let Some(existing) = bindings.get(&addr).and_then(Weak::upgrade) {
+            if !Arc::ptr_eq(&existing, &self_arc) {
+                return -(EADDRINUSE as isize);
+            }
+        }
+
+        bindings.insert(addr.clone(), Arc::downgrade(&self_arc));
+        *self.local_addr.lock() = Some(addr.clone());
+        *self.registered_addr.lock() = Some(addr);
+        0
+    }
+
+    pub fn listen(&self, backlog: i32) -> isize {
+        if self.kind != UnixSocketKind::Stream {
+            return -(EOPNOTSUPP as isize);
+        }
+        if backlog < 0 {
+            return -(EINVAL as isize);
+        }
+
+        let mut state = self.state.lock();
+        match &*state {
+            UnixSocketState::Unconnected => {
+                *state = UnixSocketState::Listening {
+                    backlog: (backlog as usize).clamp(1, 128),
+                    pending: VecDeque::new(),
+                };
+                0
+            }
+            UnixSocketState::Listening { .. } => 0,
+            UnixSocketState::Connected { .. } => -(EINVAL as isize),
+        }
+    }
+
+    pub fn accept(&self) -> Result<Arc<UnixSocketFile>, isize> {
+        let mut state = self.state.lock();
+        match &mut *state {
+            UnixSocketState::Listening { pending, .. } => pending
+                .pop_front()
+                .ok_or(-(crate::uapi::errno::EAGAIN as isize)),
+            _ => Err(-(EINVAL as isize)),
+        }
+    }
+
+    pub fn connect(&self, addr: UnixSocketAddr) -> isize {
+        match self.kind {
+            UnixSocketKind::Stream => self.connect_stream(addr),
+            UnixSocketKind::Datagram => {
+                *self.peer_addr.lock() = Some(addr);
+                0
+            }
+        }
+    }
+
+    fn connect_stream(&self, addr: UnixSocketAddr) -> isize {
+        let listener = match lookup_bound_socket(&addr) {
+            Some(listener) => listener,
+            None => return -(ECONNREFUSED as isize),
+        };
+
+        let mut listener_state = listener.state.lock();
+        let (backlog, pending) = match &mut *listener_state {
+            UnixSocketState::Listening { backlog, pending } => (*backlog, pending),
+            _ => return -(ECONNREFUSED as isize),
+        };
+
+        if pending.len() >= backlog {
+            return -(crate::uapi::errno::EAGAIN as isize);
+        }
+
+        let conn = Arc::new(SpinLock::new(UnixStreamConnection::new()));
+        let server =
+            UnixSocketFile::new_connected_stream(*self.flags.lock(), conn.clone(), StreamSide::B);
+
+        let server_local = listener.local_addr.lock().clone();
+        *server.local_addr.lock() = server_local.clone();
+        *server.peer_addr.lock() = self.local_addr.lock().clone();
+
+        {
+            let mut state = self.state.lock();
+            match &*state {
+                UnixSocketState::Unconnected => {
+                    *state = UnixSocketState::Connected {
+                        conn,
+                        side: StreamSide::A,
+                    };
+                }
+                UnixSocketState::Connected { .. } => {
+                    return -(crate::uapi::errno::EISCONN as isize);
+                }
+                UnixSocketState::Listening { .. } => return -(EINVAL as isize),
+            }
+        }
+        *self.peer_addr.lock() = server_local.or(Some(addr));
+
+        pending.push_back(server);
+        crate::kernel::syscall::io::wake_poll_waiters();
+        0
+    }
+
+    pub fn shutdown(&self, how: i32) -> isize {
+        if !(0..=2).contains(&how) {
+            return -(EINVAL as isize);
+        }
+
+        if how == 0 || how == 2 {
+            *self.shutdown_read.lock() = true;
+        }
+        if how == 1 || how == 2 {
+            *self.shutdown_write.lock() = true;
+        }
+
+        if let UnixSocketState::Connected { conn, side } = &*self.state.lock() {
+            let mut conn = conn.lock();
+            if how == 0 || how == 2 {
+                conn.close_read(*side);
+            }
+            if how == 1 || how == 2 {
+                conn.close_write(*side);
+            }
+        }
+        crate::kernel::syscall::io::wake_poll_waiters();
+        0
+    }
+
+    pub fn local_addr(&self) -> Option<UnixSocketAddr> {
+        self.local_addr.lock().clone()
+    }
+
+    pub fn peer_addr(&self) -> Option<UnixSocketAddr> {
+        self.peer_addr.lock().clone()
+    }
+
+    pub fn send_to(&self, buf: &[u8], addr: UnixSocketAddr) -> Result<usize, FsError> {
+        match self.kind {
+            UnixSocketKind::Stream => self.write(buf),
+            UnixSocketKind::Datagram => self.send_datagram(buf, Some(addr)),
+        }
+    }
+
+    fn send_datagram(&self, buf: &[u8], dest: Option<UnixSocketAddr>) -> Result<usize, FsError> {
+        if *self.shutdown_write.lock() {
+            return Err(FsError::BrokenPipe);
+        }
+        if buf.len() > DGRAM_MAX_SIZE {
+            return Err(FsError::InvalidArgument);
+        }
+
+        if let Some(peer) = self.dgram_peer.lock().as_ref().and_then(Weak::upgrade) {
+            return enqueue_datagram(&peer, buf, self.local_addr());
+        }
+
+        let dest = dest
+            .or_else(|| self.peer_addr())
+            .ok_or(FsError::DestinationAddressRequired)?;
+        let peer = lookup_bound_socket(&dest).ok_or(FsError::NotConnected)?;
+        enqueue_datagram(&peer, buf, self.local_addr())
+    }
+}
+
+impl File for UnixSocketFile {
+    fn readable(&self) -> bool {
+        if *self.shutdown_read.lock() {
+            return true;
+        }
+
+        match self.kind {
+            UnixSocketKind::Stream => match &*self.state.lock() {
+                UnixSocketState::Listening { pending, .. } => !pending.is_empty(),
+                UnixSocketState::Connected { conn, side } => {
+                    let conn = conn.lock();
+                    !conn.inbound(*side).is_empty() || conn.peer_write_closed(*side)
+                }
+                UnixSocketState::Unconnected => false,
+            },
+            UnixSocketKind::Datagram => !self.dgram_queue.lock().is_empty(),
+        }
+    }
+
+    fn writable(&self) -> bool {
+        if *self.shutdown_write.lock() {
+            return false;
+        }
+
+        match self.kind {
+            UnixSocketKind::Stream => match &*self.state.lock() {
+                UnixSocketState::Connected { conn, side } => {
+                    let conn = conn.lock();
+                    !conn.local_write_closed(*side)
+                        && !conn.peer_read_closed(*side)
+                        && conn.outbound(*side).len() < STREAM_BUFFER_CAPACITY
+                }
+                _ => false,
+            },
+            UnixSocketKind::Datagram => {
+                self.dgram_peer.lock().is_some() || self.peer_addr.lock().is_some()
+            }
+        }
+    }
+
+    fn read(&self, buf: &mut [u8]) -> Result<usize, FsError> {
+        if *self.shutdown_read.lock() {
+            return Ok(0);
+        }
+
+        match self.kind {
+            UnixSocketKind::Stream => match &*self.state.lock() {
+                UnixSocketState::Connected { conn, side } => {
+                    let mut conn = conn.lock();
+                    if conn.local_read_closed(*side) {
+                        return Ok(0);
+                    }
+                    if conn.inbound(*side).is_empty() {
+                        if conn.peer_write_closed(*side) {
+                            return Ok(0);
+                        }
+                        return Err(FsError::WouldBlock);
+                    }
+
+                    let nread = buf.len().min(conn.inbound(*side).len());
+                    let inbound = match side {
+                        StreamSide::A => &mut conn.b_to_a,
+                        StreamSide::B => &mut conn.a_to_b,
+                    };
+                    for byte in buf.iter_mut().take(nread) {
+                        *byte = inbound.pop_front().unwrap();
+                    }
+                    crate::kernel::syscall::io::wake_poll_waiters();
+                    Ok(nread)
+                }
+                _ => Err(FsError::NotConnected),
+            },
+            UnixSocketKind::Datagram => {
+                let datagram = self
+                    .dgram_queue
+                    .lock()
+                    .pop_front()
+                    .ok_or(FsError::WouldBlock)?;
+                let nread = buf.len().min(datagram.data.len());
+                buf[..nread].copy_from_slice(&datagram.data[..nread]);
+                crate::kernel::syscall::io::wake_poll_waiters();
+                Ok(nread)
+            }
+        }
+    }
+
+    fn write(&self, buf: &[u8]) -> Result<usize, FsError> {
+        if *self.shutdown_write.lock() {
+            return Err(FsError::BrokenPipe);
+        }
+
+        match self.kind {
+            UnixSocketKind::Stream => match &*self.state.lock() {
+                UnixSocketState::Connected { conn, side } => {
+                    let mut conn = conn.lock();
+                    if conn.local_write_closed(*side) {
+                        return Err(FsError::BrokenPipe);
+                    }
+                    if conn.peer_read_closed(*side) {
+                        return Err(FsError::BrokenPipe);
+                    }
+
+                    let available =
+                        STREAM_BUFFER_CAPACITY.saturating_sub(conn.outbound(*side).len());
+                    if available == 0 {
+                        return Err(FsError::WouldBlock);
+                    }
+
+                    let nwrite = buf.len().min(available);
+                    let outbound = conn.outbound_mut(*side);
+                    for &byte in &buf[..nwrite] {
+                        outbound.push_back(byte);
+                    }
+                    crate::kernel::syscall::io::wake_poll_waiters();
+                    Ok(nwrite)
+                }
+                _ => Err(FsError::NotConnected),
+            },
+            UnixSocketKind::Datagram => self.send_datagram(buf, None),
+        }
+    }
+
+    fn metadata(&self) -> Result<InodeMetadata, FsError> {
+        Ok(InodeMetadata {
+            inode_no: 0,
+            inode_type: InodeType::Socket,
+            size: 0,
+            mode: FileMode::S_IFSOCK | FileMode::from_bits_truncate(0o777),
+            uid: 0,
+            gid: 0,
+            atime: TimeSpec::zero(),
+            mtime: TimeSpec::zero(),
+            ctime: TimeSpec::zero(),
+            nlinks: 1,
+            blocks: 0,
+            rdev: 0,
+        })
+    }
+
+    fn flags(&self) -> OpenFlags {
+        *self.flags.lock()
+    }
+
+    fn set_status_flags(&self, new_flags: OpenFlags) -> Result<(), FsError> {
+        *self.flags.lock() = new_flags;
+        Ok(())
+    }
+
+    fn recvfrom(&self, buf: &mut [u8]) -> Result<(usize, Option<Vec<u8>>), FsError> {
+        match self.kind {
+            UnixSocketKind::Stream => {
+                let nread = self.read(buf)?;
+                Ok((nread, self.peer_addr().map(sockaddr_bytes)))
+            }
+            UnixSocketKind::Datagram => {
+                let datagram = self
+                    .dgram_queue
+                    .lock()
+                    .pop_front()
+                    .ok_or(FsError::WouldBlock)?;
+                let nread = buf.len().min(datagram.data.len());
+                buf[..nread].copy_from_slice(&datagram.data[..nread]);
+                Ok((nread, datagram.source.map(sockaddr_bytes)))
+            }
+        }
+    }
+
+    fn as_any(&self) -> &dyn core::any::Any {
+        self
+    }
+}
+
+impl Drop for UnixSocketFile {
+    fn drop(&mut self) {
+        if let Some(addr) = self.registered_addr.lock().take() {
+            let self_ptr = self as *const UnixSocketFile;
+            let mut bindings = UNIX_BINDINGS.lock();
+            if let Some(bound) = bindings.get(&addr).and_then(Weak::upgrade)
+                && Arc::as_ptr(&bound) == self_ptr
+            {
+                bindings.remove(&addr);
+            }
+        }
+
+        if let UnixSocketState::Connected { conn, side } = &*self.state.lock() {
+            let mut conn = conn.lock();
+            conn.close_read(*side);
+            conn.close_write(*side);
+        }
+        crate::kernel::syscall::io::wake_poll_waiters();
+    }
+}
+
+fn lookup_bound_socket(addr: &UnixSocketAddr) -> Option<Arc<UnixSocketFile>> {
+    let mut bindings = UNIX_BINDINGS.lock();
+    match bindings.get(addr).and_then(Weak::upgrade) {
+        Some(socket) => Some(socket),
+        None => {
+            bindings.remove(addr);
+            None
+        }
+    }
+}
+
+fn enqueue_datagram(
+    target: &Arc<UnixSocketFile>,
+    buf: &[u8],
+    source: Option<UnixSocketAddr>,
+) -> Result<usize, FsError> {
+    if *target.shutdown_read.lock() {
+        return Err(FsError::NotConnected);
+    }
+    let mut queue = target.dgram_queue.lock();
+    if queue.len() >= DGRAM_QUEUE_CAPACITY {
+        return Err(FsError::WouldBlock);
+    }
+    queue.push_back(UnixDatagram {
+        data: buf.to_vec(),
+        source,
+    });
+    drop(queue);
+    crate::kernel::syscall::io::wake_poll_waiters();
+    Ok(buf.len())
+}
+
+fn sockaddr_bytes(addr: UnixSocketAddr) -> Vec<u8> {
+    let path = addr.path_bytes();
+    let total_len = SOCKADDR_UN_PATH_OFFSET + path.len().min(UNIX_PATH_MAX);
+    let mut buf = vec![0u8; total_len];
+    buf[0..2].copy_from_slice(&(AF_UNIX as u16).to_ne_bytes());
+    buf[SOCKADDR_UN_PATH_OFFSET..].copy_from_slice(&path[..total_len - SOCKADDR_UN_PATH_OFFSET]);
+    buf
+}
+
+fn create_socket_node(path: &str) -> Result<(), isize> {
+    if path.is_empty() {
+        return Err(-(EINVAL as isize));
+    }
+
+    if vfs_lookup(path).is_ok() {
+        return Err(-(EADDRINUSE as isize));
+    }
+
+    let (dir_path, name) = split_path(path).map_err(|_| -(EINVAL as isize))?;
+    let parent = vfs_lookup(&dir_path).map_err(|e| e.to_errno())?;
+    let mode = FileMode::S_IFSOCK | FileMode::from_bits_truncate(0o777);
+    parent
+        .inode
+        .mknod(&name, mode, 0)
+        .map(|_| ())
+        .map_err(|e| e.to_errno())
+}
+
+pub fn wait_unix_would_block(
+    file: Arc<dyn File>,
+    task: crate::kernel::SharedTask,
+) -> Result<(), isize> {
+    drop(file);
+    crate::kernel::yield_task();
+    if crate::ipc::signal_interrupts_syscall(&task) {
+        return Err(-(EINTR as isize));
+    }
+    Ok(())
+}
+
+pub fn write_socketpair_fds(sv: *mut i32, first: usize, second: usize) -> Result<(), isize> {
+    if sv.is_null() {
+        return Err(-(EINVAL as isize));
+    }
+    write_to_user(sv, first as i32);
+    unsafe {
+        write_to_user(sv.add(1), second as i32);
+    }
+    Ok(())
+}

--- a/os/src/uapi/fcntl.rs
+++ b/os/src/uapi/fcntl.rs
@@ -281,6 +281,9 @@ bitflags! {
         /// 必须是目录 (O_DIRECTORY)
         const O_DIRECTORY = 0o200000;
 
+        /// 不跟随最终符号链接 (O_NOFOLLOW)
+        const O_NOFOLLOW  = 0o400000;
+
         /// exec 时关闭 (O_CLOEXEC)
         const O_CLOEXEC   = 0o2000000;
 

--- a/os/src/uapi/fs.rs
+++ b/os/src/uapi/fs.rs
@@ -191,6 +191,9 @@ bitflags! {
         /// 不跟随符号链接（AT_SYMLINK_NOFOLLOW）
         const SYMLINK_NOFOLLOW = 0x100;
 
+        /// 跟随符号链接（AT_SYMLINK_FOLLOW，用于 linkat 等）
+        const SYMLINK_FOLLOW = 0x400;
+
         /// 使用有效 UID/GID 而非实际 UID/GID（AT_EACCESS）
         const EACCESS = 0x200;
 

--- a/os/src/uapi/socket.rs
+++ b/os/src/uapi/socket.rs
@@ -1,5 +1,10 @@
 //! Socket options and constants
 
+// Address families
+pub const AF_UNIX: i32 = 1;
+pub const AF_LOCAL: i32 = AF_UNIX;
+pub const AF_INET: i32 = 2;
+
 // Socket levels
 pub const SOL_SOCKET: i32 = 1;
 pub const IPPROTO_TCP: i32 = 6;

--- a/os/src/vfs/adapter.rs
+++ b/os/src/vfs/adapter.rs
@@ -4,6 +4,7 @@
 
 use super::{InodeMetadata, InodeType};
 use crate::uapi::fs::{STATX_BASIC_STATS, Stat, Statx, StatxTimestamp};
+use crate::vfs::dev::{encode_linux_dev, major, minor};
 
 /// Stat 结构适配方法
 impl Stat {
@@ -16,7 +17,7 @@ impl Stat {
             st_nlink: meta.nlinks as u32,
             st_uid: meta.uid,
             st_gid: meta.gid,
-            st_rdev: meta.rdev,
+            st_rdev: encode_linux_dev(meta.rdev),
             __pad1: 0,
             st_size: meta.size as i64,
             st_blksize: 512,
@@ -60,8 +61,8 @@ impl Statx {
             stx_btime: StatxTimestamp::zeroed(),
             stx_ctime: ts(meta.ctime),
             stx_mtime: ts(meta.mtime),
-            stx_rdev_major: 0,
-            stx_rdev_minor: 0,
+            stx_rdev_major: major(meta.rdev),
+            stx_rdev_minor: minor(meta.rdev),
             stx_dev_major: 0,
             stx_dev_minor: 0,
             stx_mnt_id: 0,

--- a/os/src/vfs/dev.rs
+++ b/os/src/vfs/dev.rs
@@ -21,3 +21,52 @@ pub const fn major(dev: u64) -> u32 {
 pub const fn minor(dev: u64) -> u32 {
     (dev & 0xFFFFFFFF) as u32
 }
+
+/// 将内核内部设备号编码为 Linux 用户态 ABI 使用的 dev_t。
+#[inline]
+pub const fn encode_linux_dev(dev: u64) -> u64 {
+    let major = major(dev) as u64;
+    let minor = minor(dev) as u64;
+    ((major & 0x00000fff) << 8)
+        | ((major & 0xfffff000) << 32)
+        | (minor & 0x000000ff)
+        | ((minor & 0xffffff00) << 12)
+}
+
+/// 将 Linux 用户态 ABI 的 dev_t 解码为内核内部设备号。
+#[inline]
+pub const fn decode_linux_dev(dev: u64) -> u64 {
+    let major = ((dev & 0x00000000000fff00) >> 8) | ((dev & 0xfffff00000000000) >> 32);
+    let minor = (dev & 0x00000000000000ff) | ((dev & 0x00000ffffff00000) >> 12);
+    makedev(major as u32, minor as u32)
+}
+
+/// ext2/3/4 旧格式设备号编码，保存在 inode 的 i_block[0]。
+#[inline]
+pub const fn encode_ext4_old_dev(dev: u64) -> u32 {
+    let major = major(dev);
+    let minor = minor(dev);
+    ((major & 0xff) << 8) | (minor & 0xff)
+}
+
+/// ext2/3/4 新格式设备号编码，保存在 inode 的 i_block[1]。
+#[inline]
+pub const fn encode_ext4_new_dev(dev: u64) -> u32 {
+    let major = major(dev);
+    let minor = minor(dev);
+    (minor & 0xff) | ((major & 0xfff) << 8) | ((minor & !0xff) << 12)
+}
+
+/// 解码 ext2/3/4 旧格式设备号。
+#[inline]
+pub const fn decode_ext4_old_dev(encoded: u32) -> u64 {
+    makedev((encoded >> 8) & 0xff, encoded & 0xff)
+}
+
+/// 解码 ext2/3/4 新格式设备号。
+#[inline]
+pub const fn decode_ext4_new_dev(encoded: u32) -> u64 {
+    let major = (encoded >> 8) & 0xfff;
+    let minor = (encoded & 0xff) | ((encoded >> 12) & !0xff);
+    makedev(major, minor)
+}

--- a/os/src/vfs/error.rs
+++ b/os/src/vfs/error.rs
@@ -40,7 +40,8 @@ pub enum FsError {
     WouldBlock, // -EAGAIN(11): 非阻塞操作将阻塞
 
     // 网络相关
-    NotConnected, // -ENOTCONN(107): 套接字未连接
+    DestinationAddressRequired, // -EDESTADDRREQ(89): 需要目标地址
+    NotConnected,               // -ENOTCONN(107): 套接字未连接
 
     // 其他
     NotSupported,    // -ENOTSUP(95): 操作不支持
@@ -81,6 +82,7 @@ impl FsError {
             FsError::DirectoryNotEmpty => -ENOTEMPTY as isize,
             FsError::TooManySymlinks => -ELOOP as isize,
             FsError::NotSupported => -EOPNOTSUPP as isize,
+            FsError::DestinationAddressRequired => -EDESTADDRREQ as isize,
             FsError::NotConnected => -ENOTCONN as isize,
         }
     }

--- a/os/src/vfs/error.rs
+++ b/os/src/vfs/error.rs
@@ -27,12 +27,13 @@ pub enum FsError {
     NameTooLong,     // -ENAMETOOLONG(36): 文件名过长
 
     // 文件系统相关
-    ReadOnlyFs, // -EROFS(30): 只读文件系统
-    NoSpace,    // -ENOSPC(28): 设备空间不足
-    IoError,    // -EIO(5): I/O 错误
-    NoDevice,   // -ENODEV(19): 设备不存在
-    NoMemory,   // -ENOMEM(12): 内存不足
-    Busy,       // -EBUSY(16): 设备或资源忙
+    ReadOnlyFs,            // -EROFS(30): 只读文件系统
+    NoSpace,               // -ENOSPC(28): 设备空间不足
+    IoError,               // -EIO(5): I/O 错误
+    NoSuchDeviceOrAddress, // -ENXIO(6): 设备或地址不存在
+    NoDevice,              // -ENODEV(19): 设备不存在
+    NoMemory,              // -ENOMEM(12): 内存不足
+    Busy,                  // -EBUSY(16): 设备或资源忙
 
     // 管道相关 (新增)
     BrokenPipe, // -EPIPE(32): 管道破裂 (读端已关闭)
@@ -57,6 +58,7 @@ impl FsError {
         match self {
             FsError::NotFound => -ENOENT as isize,
             FsError::IoError => -EIO as isize,
+            FsError::NoSuchDeviceOrAddress => -ENXIO as isize,
             FsError::BadFileDescriptor => -EBADF as isize,
             FsError::WouldBlock => -EAGAIN as isize,
             FsError::NoMemory => -ENOMEM as isize,

--- a/os/src/vfs/error.rs
+++ b/os/src/vfs/error.rs
@@ -34,6 +34,7 @@ pub enum FsError {
     NoDevice,              // -ENODEV(19): 设备不存在
     NoMemory,              // -ENOMEM(12): 内存不足
     Busy,                  // -EBUSY(16): 设备或资源忙
+    CrossDeviceLink,       // -EXDEV(18): 跨设备链接/重命名
 
     // 管道相关 (新增)
     BrokenPipe, // -EPIPE(32): 管道破裂 (读端已关闭)
@@ -67,6 +68,7 @@ impl FsError {
             FsError::BadAddress => -EFAULT as isize,
             FsError::Busy => -EBUSY as isize,
             FsError::AlreadyExists => -EEXIST as isize,
+            FsError::CrossDeviceLink => -EXDEV as isize,
             FsError::NoDevice => -ENODEV as isize,
             FsError::NotDirectory => -ENOTDIR as isize,
             FsError::IsDirectory => -EISDIR as isize,
@@ -98,6 +100,7 @@ mod tests {
         kassert!(FsError::NotFound.to_errno() == -crate::uapi::errno::ENOENT as isize);
         kassert!(FsError::PermissionDenied.to_errno() == -crate::uapi::errno::EACCES as isize);
         kassert!(FsError::AlreadyExists.to_errno() == -crate::uapi::errno::EEXIST as isize);
+        kassert!(FsError::CrossDeviceLink.to_errno() == -crate::uapi::errno::EXDEV as isize);
         kassert!(FsError::BadAddress.to_errno() == -crate::uapi::errno::EFAULT as isize);
         kassert!(FsError::NotSeekable.to_errno() == -crate::uapi::errno::ESPIPE as isize);
         kassert!(FsError::NotTty.to_errno() == -crate::uapi::errno::ENOTTY as isize);

--- a/os/src/vfs/fd_table.rs
+++ b/os/src/vfs/fd_table.rs
@@ -314,6 +314,10 @@ impl FDTable {
     /// 返回新的 fd，与 old_fd 指向同一个 `Arc<dyn File>` (共享 offset)。
     /// 新分配的 fd 是 >= min_fd 的最小未使用文件描述符。
     pub fn dup_from(&self, old_fd: usize, min_fd: usize, flags: FdFlags) -> Result<usize, FsError> {
+        if min_fd >= self.max_fds {
+            return Err(FsError::InvalidArgument);
+        }
+
         let file = self.get(old_fd)?;
         let mut files = self.files.lock();
         let mut fd_flags = self.fd_flags.lock();

--- a/os/src/vfs/file.rs
+++ b/os/src/vfs/file.rs
@@ -167,8 +167,8 @@ pub trait File: Send + Sync {
 
     /// 设置管道大小（可选方法，用于 F_SETPIPE_SZ）
     ///
-    /// 默认返回 `NotSupported`，仅适用于 PipeFile
-    fn set_pipe_size(&self, _size: usize) -> Result<(), FsError> {
+    /// 成功返回实际设置后的管道大小。默认返回 `NotSupported`，仅适用于 PipeFile。
+    fn set_pipe_size(&self, _size: usize) -> Result<usize, FsError> {
         Err(FsError::NotSupported)
     }
 

--- a/os/src/vfs/impls/pipe_file.rs
+++ b/os/src/vfs/impls/pipe_file.rs
@@ -3,9 +3,14 @@
 //! 管道是流式单向通信设备，读端和写端分别由两个 [`PipeFile`] 实例表示。
 
 use crate::sync::SpinLock;
-use crate::vfs::{File, FileMode, FsError, InodeMetadata, InodeType, OpenFlags, TimeSpec};
-use alloc::collections::VecDeque;
+use crate::vfs::{Dentry, File, FileMode, FsError, InodeMetadata, InodeType, OpenFlags, TimeSpec};
+use alloc::collections::{BTreeMap, VecDeque};
 use alloc::sync::Arc;
+
+lazy_static::lazy_static! {
+    static ref NAMED_FIFO_REGISTRY: SpinLock<BTreeMap<usize, Arc<SpinLock<PipeRingBuffer>>>> =
+        SpinLock::new(BTreeMap::new());
+}
 
 /// 管道环形缓冲区
 ///
@@ -19,6 +24,10 @@ struct PipeRingBuffer {
     write_end_count: usize,
     /// 读端引用计数 (用于检测读端关闭)
     read_end_count: usize,
+    /// 是否曾经打开过写端。命名 FIFO 需要区分“尚无写端”和“写端已关闭”。
+    ever_had_writer: bool,
+    /// 是否曾经打开过读端。命名 FIFO 需要区分“尚无读端”和“读端已关闭”。
+    ever_had_reader: bool,
 }
 
 impl PipeRingBuffer {
@@ -32,7 +41,17 @@ impl PipeRingBuffer {
             capacity: Self::DEFAULT_CAPACITY,
             write_end_count: 0,
             read_end_count: 0,
+            ever_had_writer: false,
+            ever_had_reader: false,
         }
+    }
+
+    fn can_read_now(&self) -> bool {
+        !self.buffer.is_empty() || (self.ever_had_writer && self.write_end_count == 0)
+    }
+
+    fn can_write_now(&self) -> bool {
+        self.read_end_count > 0 && self.buffer.len() < self.capacity
     }
 
     /// 获取管道容量
@@ -57,13 +76,16 @@ impl PipeRingBuffer {
 
     /// 读取数据 (非阻塞)
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, FsError> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+
         if self.buffer.is_empty() {
             // 写端已关闭且缓冲区为空 -> EOF
-            if self.write_end_count == 0 {
+            if self.ever_had_writer && self.write_end_count == 0 {
                 return Ok(0);
             }
-            // 写端未关闭但缓冲区为空 -> 暂时返回0 (TODO: 配合调度器实现阻塞)
-            return Ok(0);
+            return Err(FsError::WouldBlock);
         }
 
         let nread = buf.len().min(self.buffer.len());
@@ -71,20 +93,29 @@ impl PipeRingBuffer {
             *byte = self.buffer.pop_front().unwrap();
         }
 
+        crate::kernel::syscall::io::wake_poll_waiters();
         Ok(nread)
     }
 
     /// 写入数据 (非阻塞)
     fn write(&mut self, buf: &[u8]) -> Result<usize, FsError> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+
         // 读端已关闭 -> EPIPE (应发送 SIGPIPE 信号)
-        if self.read_end_count == 0 {
+        if self.ever_had_reader && self.read_end_count == 0 {
             return Err(FsError::BrokenPipe);
+        }
+
+        if self.read_end_count == 0 {
+            return Err(FsError::WouldBlock);
         }
 
         // 缓冲区已满 -> 暂时只写入可用空间 (TODO: 阻塞等待)
         let available = self.capacity - self.buffer.len();
         if available == 0 {
-            return Ok(0);
+            return Err(FsError::WouldBlock);
         }
 
         let nwrite = buf.len().min(available);
@@ -92,6 +123,7 @@ impl PipeRingBuffer {
             self.buffer.push_back(byte);
         }
 
+        crate::kernel::syscall::io::wake_poll_waiters();
         Ok(nwrite)
     }
 }
@@ -117,6 +149,26 @@ pub struct PipeFile {
 enum PipeEnd {
     Read,
     Write,
+    ReadWrite,
+}
+
+impl PipeEnd {
+    fn from_flags(readable: bool, writable: bool) -> Self {
+        match (readable, writable) {
+            (true, true) => Self::ReadWrite,
+            (true, false) => Self::Read,
+            (false, true) => Self::Write,
+            (false, false) => unreachable!(),
+        }
+    }
+
+    fn readable(self) -> bool {
+        matches!(self, Self::Read | Self::ReadWrite)
+    }
+
+    fn writable(self) -> bool {
+        matches!(self, Self::Write | Self::ReadWrite)
+    }
 }
 
 impl PipeFile {
@@ -136,6 +188,8 @@ impl PipeFile {
             let mut buf = buffer.lock();
             buf.read_end_count = 1;
             buf.write_end_count = 1;
+            buf.ever_had_reader = true;
+            buf.ever_had_writer = true;
         }
 
         let read_end = Self {
@@ -153,6 +207,54 @@ impl PipeFile {
         };
 
         (read_end, write_end)
+    }
+
+    /// 以命名 FIFO 的语义打开一个目录项。
+    pub fn open_fifo(dentry: Arc<Dentry>, flags: OpenFlags) -> Result<Self, FsError> {
+        let readable = flags.readable();
+        let writable = flags.writable();
+
+        if !readable && !writable {
+            return Err(FsError::InvalidArgument);
+        }
+
+        let key = Arc::as_ptr(&dentry) as usize;
+        let buffer = {
+            let mut registry = NAMED_FIFO_REGISTRY.lock();
+            registry
+                .entry(key)
+                .or_insert_with(|| Arc::new(SpinLock::new(PipeRingBuffer::new())))
+                .clone()
+        };
+
+        if writable
+            && !readable
+            && flags.contains(OpenFlags::O_NONBLOCK)
+            && buffer.lock().read_end_count == 0
+        {
+            return Err(FsError::NoSuchDeviceOrAddress);
+        }
+
+        {
+            let mut buf = buffer.lock();
+            if readable {
+                buf.read_end_count += 1;
+                buf.ever_had_reader = true;
+            }
+            if writable {
+                buf.write_end_count += 1;
+                buf.ever_had_writer = true;
+            }
+        }
+
+        crate::kernel::syscall::io::wake_poll_waiters();
+
+        Ok(Self {
+            buffer,
+            end_type: PipeEnd::from_flags(readable, writable),
+            flags: SpinLock::new(flags),
+            owner: SpinLock::new(None),
+        })
     }
 
     /// 设置文件状态标志 (F_SETFL)
@@ -175,27 +277,25 @@ impl PipeFile {
 
 impl File for PipeFile {
     fn readable(&self) -> bool {
-        // 读端始终可读；buffer 为空且写端未关闭时 read() 返回 Ok(0) 或 WouldBlock
-        self.end_type == PipeEnd::Read
+        self.end_type.readable() && self.buffer.lock().can_read_now()
     }
 
     fn writable(&self) -> bool {
-        if self.end_type != PipeEnd::Write {
+        if !self.end_type.writable() {
             return false;
         }
-        // 写端可写当读端仍然打开（buffer 满时 write() 返回 Ok(0) 或 WouldBlock）
-        self.buffer.lock().read_end_count > 0
+        self.buffer.lock().can_write_now()
     }
 
     fn read(&self, buf: &mut [u8]) -> Result<usize, FsError> {
-        if self.end_type != PipeEnd::Read {
+        if !self.end_type.readable() {
             return Err(FsError::InvalidArgument);
         }
         self.buffer.lock().read(buf)
     }
 
     fn write(&self, buf: &[u8]) -> Result<usize, FsError> {
-        if self.end_type != PipeEnd::Write {
+        if !self.end_type.writable() {
             return Err(FsError::InvalidArgument);
         }
         self.buffer.lock().write(buf)
@@ -257,6 +357,12 @@ impl Drop for PipeFile {
         match self.end_type {
             PipeEnd::Read => buf.read_end_count -= 1,
             PipeEnd::Write => buf.write_end_count -= 1,
+            PipeEnd::ReadWrite => {
+                buf.read_end_count -= 1;
+                buf.write_end_count -= 1;
+            }
         }
+        drop(buf);
+        crate::kernel::syscall::io::wake_poll_waiters();
     }
 }

--- a/os/src/vfs/impls/pipe_file.rs
+++ b/os/src/vfs/impls/pipe_file.rs
@@ -61,9 +61,10 @@ impl PipeRingBuffer {
 
     /// 设置管道容量
     fn set_capacity(&mut self, new_capacity: usize) -> Result<(), FsError> {
-        if !(Self::MIN_CAPACITY..=Self::MAX_CAPACITY).contains(&new_capacity) {
+        if new_capacity > Self::MAX_CAPACITY {
             return Err(FsError::InvalidArgument);
         }
+        let new_capacity = new_capacity.max(Self::MIN_CAPACITY);
 
         // 如果新容量小于当前数据量，拒绝修改
         if new_capacity < self.buffer.len() {

--- a/os/src/vfs/impls/pipe_file.rs
+++ b/os/src/vfs/impls/pipe_file.rs
@@ -270,8 +270,10 @@ impl PipeFile {
     }
 
     /// 设置管道大小 (F_SETPIPE_SZ)
-    pub fn set_pipe_size(&self, new_size: usize) -> Result<(), FsError> {
-        self.buffer.lock().set_capacity(new_size)
+    pub fn set_pipe_size(&self, new_size: usize) -> Result<usize, FsError> {
+        let mut buffer = self.buffer.lock();
+        buffer.set_capacity(new_size)?;
+        Ok(buffer.get_capacity())
     }
 }
 
@@ -331,8 +333,8 @@ impl File for PipeFile {
         Ok(self.buffer.lock().get_capacity())
     }
 
-    fn set_pipe_size(&self, size: usize) -> Result<(), FsError> {
-        self.buffer.lock().set_capacity(size)
+    fn set_pipe_size(&self, size: usize) -> Result<usize, FsError> {
+        PipeFile::set_pipe_size(self, size)
     }
 
     fn get_owner(&self) -> Result<i32, FsError> {

--- a/os/src/vfs/inode.rs
+++ b/os/src/vfs/inode.rs
@@ -105,7 +105,7 @@ pub enum InodeType {
 }
 
 bitflags::bitflags! {
-    #[derive(Debug, Clone, Copy)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     /// 文件权限和类型（与 POSIX 兼容）
     pub struct FileMode: u32 {
         // 文件类型掩码

--- a/os/src/vfs/tests/devno.rs
+++ b/os/src/vfs/tests/devno.rs
@@ -94,3 +94,39 @@ test_case!(test_devno_consistency, {
     kassert!(major(dev1) == major(dev2));
     kassert!(minor(dev1) == minor(dev2));
 });
+
+test_case!(test_linux_dev_encoding_roundtrip, {
+    for maj in [0, 1, 8, 254, 4095] {
+        for min in [0, 1, 3, 255, 256, 4096] {
+            let dev = makedev(maj, min);
+            let encoded = encode_linux_dev(dev);
+            kassert!(decode_linux_dev(encoded) == dev);
+        }
+    }
+});
+
+test_case!(test_linux_dev_known_null_encoding, {
+    let dev = makedev(chrdev_major::MEM, 3);
+    kassert!(encode_linux_dev(dev) == 0x103);
+    kassert!(decode_linux_dev(0x103) == dev);
+});
+
+test_case!(test_ext4_old_dev_encoding_roundtrip, {
+    for maj in [0, 1, 8, 254, 255] {
+        for min in [0, 1, 3, 16, 255] {
+            let dev = makedev(maj, min);
+            let encoded = encode_ext4_old_dev(dev);
+            kassert!(decode_ext4_old_dev(encoded) == dev);
+        }
+    }
+});
+
+test_case!(test_ext4_new_dev_encoding_roundtrip, {
+    for maj in [0, 1, 8, 254, 4095] {
+        for min in [0, 1, 3, 255, 256, 4096] {
+            let dev = makedev(maj, min);
+            let encoded = encode_ext4_new_dev(dev);
+            kassert!(decode_ext4_new_dev(encoded) == dev);
+        }
+    }
+});

--- a/os/src/vfs/tests/pipe.rs
+++ b/os/src/vfs/tests/pipe.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::fs::tmpfs::TmpFs;
 use crate::vfs::PipeFile;
 use crate::{kassert, test_case};
 
@@ -159,4 +160,45 @@ test_case!(test_pipe_zero_length_operations, {
     let result = read_file.read(&mut buf);
     kassert!(result.is_ok());
     kassert!(result.unwrap() == 0);
+});
+
+test_case!(test_named_fifo_shared_buffer, {
+    let fs = TmpFs::new(0);
+    let root = fs.root_inode();
+    let inode = root
+        .mknod(
+            "fifo",
+            FileMode::S_IFIFO | FileMode::S_IRUSR | FileMode::S_IWUSR,
+            0,
+        )
+        .unwrap();
+    let dentry = Dentry::new(String::from("fifo"), inode);
+
+    let read_end = PipeFile::open_fifo(dentry.clone(), OpenFlags::O_RDONLY).unwrap();
+    let write_end = PipeFile::open_fifo(dentry, OpenFlags::O_WRONLY).unwrap();
+
+    let write_file: Arc<dyn File> = Arc::new(write_end);
+    let read_file: Arc<dyn File> = Arc::new(read_end);
+
+    kassert!(write_file.write(b"named fifo").unwrap() == 10);
+
+    let mut buf = [0u8; 10];
+    kassert!(read_file.read(&mut buf).unwrap() == 10);
+    kassert!(&buf == b"named fifo");
+});
+
+test_case!(test_named_fifo_nonblock_write_without_reader, {
+    let fs = TmpFs::new(0);
+    let root = fs.root_inode();
+    let inode = root
+        .mknod(
+            "fifo",
+            FileMode::S_IFIFO | FileMode::S_IRUSR | FileMode::S_IWUSR,
+            0,
+        )
+        .unwrap();
+    let dentry = Dentry::new(String::from("fifo"), inode);
+
+    let result = PipeFile::open_fifo(dentry, OpenFlags::O_WRONLY | OpenFlags::O_NONBLOCK);
+    kassert!(matches!(result, Err(FsError::NoSuchDeviceOrAddress)));
 });


### PR DESCRIPTION
# PR: 提升 OS Contest 测试兼容性与文件系统/syscall 语义

## 背景

本分支基于 `main`，围绕 OS Contest 官方测试镜像运行过程中的实际缺口，补齐了一批 Linux/POSIX 兼容语义。改动重点集中在 VFS、tmpfs/ext4、文件相关 syscall、部分网络 syscall，以及官方测试常见的 BusyBox/musl 行为。

分支范围：

- 当前分支：`ccy-dev01`
- 对比基线：`main`
- 提交数量：41
- 主要影响目录：`os/src/vfs`、`os/src/fs`、`os/src/kernel/syscall`、`os/src/net`

## 改动摘要

本分支主要完成以下内容：

- 支持 mknod 设备号编码/解码，并在 `stat` 结果中正确报告 `st_rdev`。
- 补齐 tmpfs/ext4 对字符设备、块设备、FIFO、socket、普通文件等特殊节点的元数据支持。
- 支持 named FIFO 打开语义、pipe size 查询和设置边界。
- 新增最小 Unix domain socket 支持，覆盖基础本地 socket 使用场景。
- 实现 `linkat`、tmpfs hard link、tmpfs rename，并修正跨设备 link、unlinkat removedir、rmdir link count 等语义。
- 收紧 `openat`、`faccessat`、`fchmodat`、`fchownat`、`statx/fstatat`、`utimensat` 等 syscall 的 flag 和空路径处理。
- 补齐 `O_NOFOLLOW`、`O_CLOEXEC`、`F_DUPFD` 下界、`getcwd` 小缓冲区返回 `ERANGE` 等 Linux 行为。
- 保留路径最后组件的 `.`、`..` 和尾部 `/` 语义，按 syscall 分别返回更接近 Linux 的错误码。
- 强化 `renameat2` 对空路径、特殊组件、尾部斜杠、目标类型校验的处理。
- 支持 `fchmodat(..., "", mode, AT_EMPTY_PATH)`，修复 BusyBox `cp` preserve permissions 阶段返回 `EINVAL` 的问题。

## 文件系统与 VFS

### 设备号与特殊文件

新增并使用 Linux 设备号编码/解码辅助函数，使 `mknodat` 创建的字符设备、块设备可以在 `stat` 中正确反映 `st_rdev`。

涉及内容：

- VFS 设备号 helper。
- `mknodat` 解码用户态传入的 `dev_t`。
- `stat`/`statx` 输出设备号。
- tmpfs/ext4 保存特殊 inode 的 rdev 和 file type。

### tmpfs 语义增强

tmpfs 增强了特殊文件和目录项操作支持：

- 精确解析 `mknod` 文件类型。
- 支持 FIFO、字符设备、块设备、socket、普通文件的创建元数据。
- 支持 hard link。
- 支持 rename。
- rmdir 时维护 link count。
- chmod/chown/timestamps 等元数据路径保持可写。

### ext4 语义增强

ext4 侧补齐：

- mknod 设备元数据。
- rename 目标类型校验。
- 目录覆盖非目录返回 `ENOTDIR`。
- 非目录覆盖目录返回 `EISDIR`。

### FIFO 与 pipe

新增 named FIFO 打开支持，并改进 pipe 相关行为：

- `open` FIFO 时返回 pipe file。
- `F_GETPIPE_SZ` 返回实际 pipe size。
- `F_SETPIPE_SZ` 对过小值进行最小值 clamp。

## syscall 兼容性

### 路径和空路径处理

本分支修复了一批空路径行为：

- `openat("")` 返回 `ENOENT`。
- `readlinkat("")` 返回 `ENOENT`。
- `faccessat("")` 返回 `ENOENT`。
- `fchmodat/fchownat("")` 在无 `AT_EMPTY_PATH` 时返回 `ENOENT`。
- `linkat` 源路径为空返回 `ENOENT`。
- `renameat2` old/new path 为空返回 `ENOENT`。

同时新增 `split_parent_preserving_basename()`，避免全局路径拆分提前吞掉最后组件 `.` 和 `..`。不同 syscall 对 final component 的语义不同，因此本分支没有粗暴修改全局 `split_path`，而是在 syscall 层分别处理。

### open/fcntl

改动包括：

- `openat` 支持 `O_NOFOLLOW`。
- `openat` 支持 `O_CLOEXEC`。
- `openat` 拒绝 `O_CREAT` 创建目录目标的错误路径。
- `fcntl(F_DUPFD)` 校验 lower bound。
- pipe size 查询和设置更贴近 Linux 行为。

### access/stat/chmod/chown/utimensat

补齐内容：

- `faccessat` flag 校验。
- `fstatat/statx` flag 收紧。
- `utimensat` 支持 `AT_EMPTY_PATH`。
- `fchmodat/fchownat` flag 校验。
- `fchmodat` 支持 `AT_EMPTY_PATH`，可通过 fd 对已打开文件 chmod。

### mknod

本分支修复：

- `mknod(path, 0644)` 默认创建普通文件。
- `mknod(S_IFDIR)` 返回 `EPERM`。
- mknod 目标路径尾部斜杠按 Linux 错误码处理。
- mknod 特殊文件类型和设备号在 tmpfs/ext4/stat 之间贯通。

### link/unlink/rename

新增/修复：

- 实现 `linkat`。
- tmpfs 支持 hard link。
- 跨设备 hard link 返回 `EXDEV`。
- `unlinkat(..., AT_REMOVEDIR)` 分流到 rmdir。
- tmpfs 支持 rename。
- `renameat2` 处理空路径、`.`/`..`、尾部斜杠、目标类型冲突。
- ext4 rename 校验目录和非目录覆盖类型。

### 尾部斜杠语义

本分支对不同 syscall 分别实现尾部 `/` 行为：

- `mkdirat("new/")`、`mkdirat("new//")` 可以成功。
- `mkdirat("file/")`、`mkdirat("dir/")`、`mkdirat("/")` 返回 `EEXIST`。
- `mknodat/symlinkat/linkat` 创建目标带尾部 `/` 时按 Linux 行为区分 `ENOENT`、`EEXIST`、`ENOTDIR`。
- `renameat2` 源路径和目标路径尾部 `/` 分别校验是否必须为目录。

## 网络

新增最小 Unix domain socket 支持：

- 新增 `os/src/net/unix_socket.rs`。
- 扩展 socket syscall 路径，支持基础 Unix socket 创建、地址绑定、连接、收发和选项处理。
- 补齐 socket 相关错误码和地址处理边界。

这部分主要用于提升 BusyBox、libc、网络测试中对本地 socket 的基础兼容性，不等同于完整 Linux Unix socket 实现。

## 主要提交列表

```text
f06cbeb vfs: add device number encoding helpers
2dead4e syscall: decode mknodat device numbers
f4fa8dd vfs: report device numbers in stat results
57561b1 tmpfs: parse mknod file types exactly
c82d7ef vfs: derive equality for file modes
ac8c926 ext4: support mknod device metadata
4e9aa7d vfs: support opening named fifos
3c80b50 vfs: invalidate global dentry cache on removal
393e80f net: add minimal unix domain sockets
87343be syscall: implement linkat
051de17 tmpfs: support hard links
08f3a8d tmpfs: support rename
57c42bc syscall: route unlinkat removedir to rmdir
c1a9ed1 vfs: return exdev for cross-device links
dccf4eb tmpfs: update link counts on rmdir
3598bbd syscall: validate chmod chown at flags
766a8b9 syscall: support utimensat empty path
35384fa syscall: tighten stat at path flags
facacc6 syscall: reject creat directory opens
b4def61 fcntl: return actual pipe size
8b1d325 pipe: clamp pipe size to minimum
e260f7f syscall: validate faccessat inputs
5965e7d syscall: preserve final path components
15dc8b2 syscall: reject empty open paths
084b58c syscall: support openat nofollow
d881e35 fcntl: validate dupfd lower bound
a262d98 syscall: honor openat cloexec
1590f6a syscall: reject empty readlink paths
0c95fc6 syscall: reject empty chmod chown paths
690ae3a syscall: reject empty access paths
acbf5d6 syscall: reject empty link sources
dd22c98 syscall: default mknod type to regular file
78c711c syscall: reject directory mknod with eperm
42e1b96 syscall: report erange for small getcwd buffers
0446089 syscall: reject empty rename paths
35fd318 syscall: preserve special rename components
e7e0e0c syscall: handle rename trailing slashes
563ac69 ext4: validate rename target types
035c64f syscall: allow mkdir trailing slashes
cba140e syscall: handle creation trailing slashes
0fda713 syscall: support fchmodat empty path
```

## 验证

已使用官方测试机镜像进行格式和编译检查：

```bash
docker run --rm -v "$PWD":/workspace -w /workspace/os \
  zhouzhouyi/os-contest:20260510 \
  bash -lc 'cargo fmt --check && cargo check'
```

结果：通过。

说明：

- 检查输出中仍有大量既有 warning，本 PR 未处理这些存量 warning。
- 本地宿主机上 `os/target` 和 `os/fs-riscv.img` 曾因测试镜像生成物归属为 root 导致直接 `cargo check` 权限失败，因此最终以指定 Docker 镜像内结果为准。

## 风险与边界

- Unix domain socket 是最小可用实现，不是完整 Linux 语义。
- 多数路径语义修复按当前测试和 Linux 探测行为实现，仍可能存在少量 errno 优先级差异。
- ext4 写路径仍可能受底层库写放大影响，性能问题不在本 PR 中完全解决。
- 本 PR 强化了大量 syscall flag 校验，若用户程序依赖旧的宽松行为，可能暴露新的错误返回。

