### PR TITLE
Fix:iperf Follow-up Robustness And PR CI

### DIFF
--- a/os/src/kernel/syscall/io.rs
+++ b/os/src/kernel/syscall/io.rs
@@ -84,6 +84,20 @@ fn wait_for_would_block(file: Arc<dyn File>, task: crate::kernel::SharedTask) ->
     Ok(())
 }
 
+fn file_read_ready(file: &Arc<dyn File>) -> bool {
+    if let Some(pipe_file) = file.as_any().downcast_ref::<crate::vfs::PipeFile>() {
+        return pipe_file.read_ready();
+    }
+    file.readable()
+}
+
+fn file_write_ready(file: &Arc<dyn File>) -> bool {
+    if let Some(pipe_file) = file.as_any().downcast_ref::<crate::vfs::PipeFile>() {
+        return pipe_file.write_ready();
+    }
+    file.writable()
+}
+
 /// 向文件描述符写入数据
 pub fn write(fd: usize, buf: *const u8, count: usize) -> isize {
     loop {
@@ -671,11 +685,11 @@ fn poll_with_timeout(
                     }
                 };
 
-                if (pollfd.events & POLLIN) != 0 && file.readable() {
+                if (pollfd.events & POLLIN) != 0 && file_read_ready(&file) {
                     pollfd.revents |= POLLIN;
                 }
 
-                if (pollfd.events & POLLOUT) != 0 && file.writable() {
+                if (pollfd.events & POLLOUT) != 0 && file_write_ready(&file) {
                     pollfd.revents |= POLLOUT;
                 }
 
@@ -889,14 +903,14 @@ fn select_common(
 
             let mut fd_ready = false;
             if check_read
-                && file.readable()
+                && file_read_ready(&file)
                 && let Some(ref mut set) = read_set
             {
                 set.set(fd);
                 fd_ready = true;
             }
             if check_write
-                && file.writable()
+                && file_write_ready(&file)
                 && let Some(ref mut set) = write_set
             {
                 set.set(fd);

--- a/os/src/kernel/syscall/network/connection_ops.rs
+++ b/os/src/kernel/syscall/network/connection_ops.rs
@@ -255,7 +255,12 @@ pub fn send(sockfd: i32, buf: *const u8, len: usize, _flags: i32) -> isize {
                 return n as isize;
             }
             Err(e) => {
-                pr_debug!("send: sockfd={}, len={} -> error={:?}", sockfd, chunk_len, e);
+                pr_debug!(
+                    "send: sockfd={}, len={} -> error={:?}",
+                    sockfd,
+                    chunk_len,
+                    e
+                );
                 if e == crate::vfs::FsError::WouldBlock {
                     if let Some(socket_file) = file.as_any().downcast_ref::<SocketFile>()
                         && !socket_file.flags().contains(OpenFlags::O_NONBLOCK)
@@ -325,11 +330,21 @@ pub fn recv(sockfd: i32, buf: *mut u8, len: usize, _flags: i32) -> isize {
 
         match result {
             Ok(n) => {
-                pr_debug!("recv: sockfd={}, len={} -> received={}", sockfd, chunk_len, n);
+                pr_debug!(
+                    "recv: sockfd={}, len={} -> received={}",
+                    sockfd,
+                    chunk_len,
+                    n
+                );
                 return n as isize;
             }
             Err(e) => {
-                pr_debug!("recv: sockfd={}, len={} -> error={:?}", sockfd, chunk_len, e);
+                pr_debug!(
+                    "recv: sockfd={}, len={} -> error={:?}",
+                    sockfd,
+                    chunk_len,
+                    e
+                );
                 if e == crate::vfs::FsError::WouldBlock {
                     if let Some(socket_file) = file.as_any().downcast_ref::<SocketFile>()
                         && !socket_file.flags().contains(OpenFlags::O_NONBLOCK)

--- a/os/src/kernel/syscall/network/socket_ops.rs
+++ b/os/src/kernel/syscall/network/socket_ops.rs
@@ -499,12 +499,20 @@ fn replenish_tcp_listeners(
     while network_stack().tcp_spare_listener_count(socket_file, listen_endpoint) < target {
         let new_listen_handle = match create_tcp_socket() {
             Ok(SocketHandle::Tcp(h)) => h,
-            Err(e) => return Err(e.to_errno()),
+            Err(e) => {
+                if network_stack().tcp_spare_listener_count(socket_file, listen_endpoint) > 0 {
+                    break;
+                }
+                return Err(e.to_errno());
+            }
             Ok(SocketHandle::Udp(_)) => return Err(-(crate::uapi::errno::EINVAL as isize)),
         };
 
         if let Err(e) = network_stack().tcp_listen(new_listen_handle, listen_endpoint) {
             network_stack().remove_tcp_socket(new_listen_handle);
+            if network_stack().tcp_spare_listener_count(socket_file, listen_endpoint) > 0 {
+                break;
+            }
             return Err(e.to_errno());
         }
 

--- a/os/src/net/socket.rs
+++ b/os/src/net/socket.rs
@@ -169,7 +169,9 @@ impl SocketFile {
 
     pub(crate) fn udp_push(&self, d: UdpDatagram) -> bool {
         let mut q = self.udp_rx_queue.lock();
-        if q.len() == q.capacity() {
+        if q.len() >= UDP_RXQ_MAX_CAP {
+            let _ = q.pop_front();
+        } else if q.len() == q.capacity() {
             let old_capacity = q.capacity();
             if old_capacity < UDP_RXQ_MAX_CAP {
                 let new_capacity = old_capacity

--- a/os/src/vfs/impls/pipe_file.rs
+++ b/os/src/vfs/impls/pipe_file.rs
@@ -276,18 +276,23 @@ impl PipeFile {
         buffer.set_capacity(new_size)?;
         Ok(buffer.get_capacity())
     }
+
+    pub fn read_ready(&self) -> bool {
+        self.end_type.readable() && self.buffer.lock().can_read_now()
+    }
+
+    pub fn write_ready(&self) -> bool {
+        self.end_type.writable() && self.buffer.lock().can_write_now()
+    }
 }
 
 impl File for PipeFile {
     fn readable(&self) -> bool {
-        self.end_type.readable() && self.buffer.lock().can_read_now()
+        self.end_type.readable()
     }
 
     fn writable(&self) -> bool {
-        if !self.end_type.writable() {
-            return false;
-        }
-        self.buffer.lock().can_write_now()
+        self.end_type.writable()
     }
 
     fn read(&self, buf: &mut [u8]) -> Result<usize, FsError> {


### PR DESCRIPTION
# Fix iperf Follow-up Robustness And PR CI

## 描述

本 PR 基于最新 `main` 新建分支 `fix/iperf-followup-ci`。上一轮 `fix/iperf-throughput` 已合并，本次只包含合并后 review 和本地 PR CI 预检发现的 follow-up 修复。

主要改动：

- UDP 接收队列显式使用 `UDP_RXQ_MAX_CAP` 作为长度硬上限，不再把 `VecDeque::capacity()` 当作逻辑上限。
- TCP listener 补充失败时，如果当前仍有 spare listener，则允许 `accept` 继续处理已有连接，而不是直接失败。
- 修复 CI `cargo fmt --check` 会报出的 socket connection 日志宏格式问题。
- 修复 `make run TEST=1` 中 pipe 相关测试失败：区分 `File::readable/writable` 的访问方向语义和 `poll/select` 的就绪语义。

## 背景

上一轮 iperf PR 已经把 TCP/UDP 吞吐和 parallel TCP 连接问题修到可用状态，但 review 指出两个稳定性问题：

- UDP 队列扩容逻辑用 `q.len() == q.capacity()` 判断是否达到上限。`VecDeque` 的实际 capacity 由分配器决定，可能超过请求值，因此不能保证 512 项硬上限。
- TCP listener pool 在资源压力下补充失败时会让整个 `accept` 失败。若此时已有 spare listener，继续 accept 更符合评分场景下的稳定性目标。

同时，本地按 `.github/workflows/ci.yml` 提前跑 PR 检查时发现：

- `cargo fmt --check` 会因 `connection_ops.rs` 三处 `pr_debug!` 格式失败。
- `cd os && make run TEST=1` 虽然命令退出码为 0，但测试摘要显示 2 个 pipe 测试失败。

## 关键修复

### UDP 队列上限

`udp_push` 现在先检查 `q.len() >= UDP_RXQ_MAX_CAP`，达到上限就丢弃最旧 datagram。只有未达逻辑上限且底层队列满时，才尝试 lazy reserve。

这个修复避免两类风险：

- 分配器给出的实际 capacity 超过 512，导致逻辑上限失效。
- 扩容失败后继续 `push_back`，在满队列情况下触发 panic。

### TCP listener 补充降级

`replenish_tcp_listeners` 现在在创建或 listen 新 socket 失败时，会重新检查 spare listener 数量：

- 若已有 spare listener，则停止补充并返回 `Ok(())`，让 `accept` 继续。
- 若没有 spare listener，则保留原行为，返回对应错误。

这让 parallel TCP 在资源压力下更偏向降级服务已有连接，而不是因为补池失败直接拒绝 accept。

### PR CI 修复

`connection_ops.rs` 的三处日志宏按 rustfmt 展开，解决 `cargo fmt --check` 失败。

PipeFile 原先把 `readable/writable` 同时用于“文件访问方向”和“当前是否 ready”。这会让空管道读端 `readable()` 返回 false，违反 File trait 和已有测试期望。

本次处理为：

- `PipeFile::readable/writable` 只表达端点访问方向。
- 新增 `PipeFile::read_ready/write_ready` 表达 pipe 缓冲区就绪状态。
- `poll/select` 通过 helper 对 PipeFile 使用 readiness 方法，对其他文件保持原逻辑。

这样修复单元测试，同时避免空管道在 poll/select 中被误报为可读。

## 验证

在新分支 `fix/iperf-followup-ci` 上按 CI 顺序本地验证：

- `cd os && cargo check --target riscv64gc-unknown-none-elf` 通过。
- `cd os && cargo fmt --all -- --check` 通过。
- `cd os && cargo clippy --target riscv64gc-unknown-none-elf` 通过。
- `cd os && make run TEST=1` 通过，测试摘要为 `Total: 533, Passed: 533, Failed: 0`。

本次验证使用的是基于最新 `origin/main` cherry-pick 4 个 follow-up commit 后的新分支，等价于新 PR 的差异范围。

## 风险与取舍

- UDP 队列达到 512 后仍会丢最旧 datagram。这是为了维持内存硬上限，符合 UDP 可丢包语义。
- TCP listener 补充失败时只在已有 spare listener 的情况下吞掉错误；没有 spare 时仍返回错误，避免掩盖完全不可服务状态。
- PipeFile readiness 只针对 `poll/select` 做类型分发，没有扩展 File trait，避免影响所有文件实现。
- 本 PR 不继续扩大 iperf buffer，也不修改上一轮已合并的 musl 全量测试入口。

## 本记录基于以下提交

- `e7fb6f3 net: cap udp receive queue length explicitly`
- `6242964 net: tolerate tcp listener replenishment pressure`
- `4ce6eed net: format socket connection logs`
- `5dd05f5 vfs: separate pipe access and readiness checks`

## 关联 Issue

暂无关联 Issue。
